### PR TITLE
feat(main): add permission handling and projection flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <!-- Required for Foreground Service notifications on Android 13+ -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
 
     <application
@@ -26,12 +28,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!-- Define your Foreground Service here later -->
-        <!--
+
         <service
             android:name=".AudioLoopService"
-            android:foregroundServiceType="mediaProjection|microphone" />
-        -->
+            android:foregroundServiceType="microphone|mediaProjection"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/audioloop/audioloop/AudioLoopApplication.kt
+++ b/app/src/main/java/com/audioloop/audioloop/AudioLoopApplication.kt
@@ -1,7 +1,5 @@
 package com.audioloop.audioloop
 
 import android.app.Application
-import dagger.hilt.android.HiltAndroidApp
 
-@HiltAndroidApp
 class AudioLoopApplication : Application()

--- a/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
@@ -1,58 +1,214 @@
 package com.audioloop.audioloop
 
+import android.app.Activity
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
-import dagger.hilt.android.AndroidEntryPoint
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 
-@AndroidEntryPoint
+// Assuming you'll add Hilt annotations if this service needs injected dependencies
+// For now, keeping it as a standard Service.
 class AudioLoopService : Service() {
 
-    companion object {
-        private const val NOTIFICATION_ID = 1
-        private const val NOTIFICATION_CHANNEL_ID = "AudioLoopServiceChannel"
+    private lateinit var mediaProjectionManager: MediaProjectionManager
+    private var notificationManager: NotificationManager? = null
+
+    // Placeholder for actual audio capture logic
+    private fun startLoopbackAudio() {
+        Log.d(TAG, "Loopback audio (supposedly) started.")
+        // TODO: Implement actual audio capture using currentMediaProjection
+        // This is where you would create AudioRecord with AudioPlaybackCaptureConfiguration
+        if (currentMediaProjection == null) {
+            Log.w(TAG, "Attempted to start loopback audio, but MediaProjection is not available.")
+            // Consider stopping the service or a part of it if projection is essential
+            return
+        }
+        // Example:
+        // val config = AudioPlaybackCaptureConfiguration.Builder(currentMediaProjection!!)
+        //   .addMatchingUsage(AudioAttributes.USAGE_MEDIA) // Capture media like music, games
+        //   .build()
+        // val audioFormat = AudioFormat.Builder()...build()
+        // audioRecord = AudioRecord.Builder()
+        //   .setAudioFormat(audioFormat)
+        //   .setAudioPlaybackCaptureConfig(config)
+        //   .build()
+        // audioRecord.startRecording()
+        // Start a thread to read from audioRecord
+    }
+
+    private fun stopLoopbackAudio() {
+        Log.d(TAG, "Loopback audio (supposedly) stopped.")
+        // TODO: Stop AudioRecord and release resources
+        // audioRecord?.stop()
+        // audioRecord?.release()
+        // audioRecord = null
+    }
+
+    private fun startForegroundNotification() {
+        val channelId = "AudioLoopServiceChannel"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Audio Loop Service",
+                NotificationManager.IMPORTANCE_LOW // Use LOW or MIN to avoid sound/vibration if not critical
+            )
+            notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager?.createNotificationChannel(channel)
+        }
+
+        val notification: Notification = NotificationCompat.Builder(this, channelId)
+            .setContentTitle("AudioLoop Service Active")
+            .setContentText(if (isProjectionSetup()) "Capturing selected app" else "Ready to select app")
+            .setSmallIcon(R.mipmap.ic_launcher) // Replace with your app's icon
+            .setOngoing(true) // Makes the notification non-dismissable
+            .build()
+        try {
+            startForeground(SERVICE_NOTIFICATION_ID, notification)
+            Log.d(TAG, "Service started in foreground.")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error starting foreground service", e)
+             // This can happen if the service is started from background without proper permissions on Android 12+ for foreground service launch
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service onCreate")
+        mediaProjectionManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        _isRunning.postValue(false) // Initial state
+        clearProjection() // Ensure projection is clear on service creation
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(NOTIFICATION_ID, createNotification())
+        val action = intent?.action
+        Log.d(TAG, "onStartCommand, action: $action")
 
-        // TODO:
-        // 1. Get MediaProjection token from the intent.
-        // 2. Initialize AudioPlaybackCapture using the MediaProjection.
-        // 3. Initialize AudioRecord to capture microphone input.
-        // 4. Initialize AudioTrack to play back mixed audio.
-        // 5. Create threads for capturing, mixing, and playback.
-        // 6. Start the audio processing loop.
+        when (action) {
+            ACTION_START_SERVICE -> {
+                _isRunning.postValue(true)
+                clearProjection() // Clear any existing projection when explicitly starting
+                startForegroundNotification()
+                startLoopbackAudio() // Or prepare for it
+            }
+            ACTION_STOP_SERVICE -> {
+                _isRunning.postValue(false)
+                stopLoopbackAudio()
+                clearProjection()
+                stopForeground(true)
+                stopSelf()
+            }
+            ACTION_SETUP_PROJECTION -> {
+                if (!_isRunning.value!!) {
+                     Log.w(TAG, "ACTION_SETUP_PROJECTION received but service is not running. Starting service first.")
+                    _isRunning.postValue(true)
+                    startForegroundNotification() // Ensure service is foreground before getMediaProjection
+                } else {
+                    // Refresh notification if already running to update text potentially
+                    startForegroundNotification()
+                }
 
+                val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
+                val data: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(EXTRA_DATA_INTENT, Intent::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(EXTRA_DATA_INTENT)
+                }
+
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    try {
+                        val projection = mediaProjectionManager.getMediaProjection(resultCode, data)
+                        if (projection != null) {
+                            currentMediaProjection = projection
+                            currentMediaProjection?.registerCallback(mediaProjectionCallback, null)
+                            Log.i(TAG, "MediaProjection obtained from MainActivity's result and stored.")
+                            // Potentially start audio capture now if it wasn't started or needs reconfiguring
+                            // startLoopbackAudio() // if it depends on having currentMediaProjection
+                        } else {
+                             Log.e(TAG, "getMediaProjection returned null despite RESULT_OK.")
+                             clearProjection()
+                        }
+                    } catch (e: SecurityException) {
+                        Log.e(TAG, "SecurityException when trying to get MediaProjection. This should not happen if service is in foreground.", e)
+                        clearProjection()
+                        // This indicates a deeper issue, perhaps service wasn't truly foreground
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Exception obtaining MediaProjection", e)
+                        clearProjection()
+                    }
+                } else {
+                    Log.w(TAG, "ACTION_SETUP_PROJECTION: Failed to get valid data from intent. ResultCode: $resultCode")
+                    clearProjection()
+                }
+                // Update notification text after attempting projection setup
+                startForegroundNotification()
+                // Update LiveData for UI
+                 _isRunning.postValue(_isRunning.value) // Force re-notify to update UI
+            }
+        }
         return START_NOT_STICKY
+    }
+
+    private val mediaProjectionCallback = object : MediaProjection.Callback() {
+        override fun onStop() {
+            super.onStop()
+            Log.w(TAG, "MediaProjection session stopped (onStop callback).")
+            clearProjection()
+            // Potentially stop audio capture or the service itself if projection is critical
+            // stopLoopbackAudio()
+             _isRunning.postValue(_isRunning.value) // Update UI
+            startForegroundNotification() // Update notification text
+            // if (/* projection is essential */) { stopSelf(); }
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        // TODO:
-        // 1. Stop all audio threads.
-        // 2. Release AudioRecord, AudioTrack, and other resources.
-        // 3. Stop foreground service.
+        Log.d(TAG, "Service onDestroy")
+        stopLoopbackAudio()
+        clearProjection()
+        _isRunning.postValue(false)
     }
 
-    private fun createNotification(): Notification {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val serviceChannel = NotificationChannel(
-                NOTIFICATION_CHANNEL_ID, "Audio Loop Service Channel", NotificationManager.IMPORTANCE_DEFAULT
-            )
-            getSystemService(NotificationManager::class.java).createNotificationChannel(serviceChannel)
+    override fun onBind(intent: Intent?): IBinder? {
+        return null // Not a bound service
+    }
+
+    companion object {
+        private const val TAG = "AudioLoopService"
+        private const val SERVICE_NOTIFICATION_ID = 12345
+
+        const val ACTION_START_SERVICE = "com.audioloop.audioloop.ACTION_START_SERVICE"
+        const val ACTION_STOP_SERVICE = "com.audioloop.audioloop.ACTION_STOP_SERVICE"
+        const val ACTION_SETUP_PROJECTION = "com.audioloop.audioloop.ACTION_SETUP_PROJECTION"
+
+        const val EXTRA_RESULT_CODE = "com.audioloop.audioloop.EXTRA_RESULT_CODE"
+        const val EXTRA_DATA_INTENT = "com.audioloop.audioloop.EXTRA_DATA_INTENT"
+
+        private var currentMediaProjection: MediaProjection? = null
+        private val _isRunning = MutableLiveData<Boolean>()
+        val isRunning: LiveData<Boolean> = _isRunning
+
+        fun isProjectionSetup(): Boolean {
+            return currentMediaProjection != null
         }
 
-        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("AudioLoop Active").setContentText("Audio loopback and mixing is running.")
-            // .setSmallIcon(R.drawable.ic_notification) // TODO: Add notification icon
-            .build()
+        fun clearProjection() {
+            Log.d(TAG, "Clearing MediaProjection.")
+            currentMediaProjection?.stop()
+            currentMediaProjection = null
+        }
     }
-
-    override fun onBind(intent: Intent?): IBinder? = null
 }
+

--- a/app/src/main/java/com/audioloop/audioloop/MainActivity.kt
+++ b/app/src/main/java/com/audioloop/audioloop/MainActivity.kt
@@ -1,24 +1,181 @@
 package com.audioloop.audioloop
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.media.projection.MediaProjectionManager // Only MediaProjectionManager is needed here
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.audioloop.audioloop.databinding.ActivityMainBinding
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
+    private var isServiceRunning = false // Tracks the service's LiveData state
+
+    private lateinit var mediaProjectionManager: MediaProjectionManager // Correct
+
+    private val requiredPermissions = mutableListOf(
+        Manifest.permission.RECORD_AUDIO
+    ).apply {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            add(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }.toTypedArray()
+
+    private val requestPermissionsLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            var allPermissionsGranted = true
+            permissions.entries.forEach {
+                if (!it.value) {
+                    allPermissionsGranted = false
+                }
+            }
+
+            if (allPermissionsGranted) {
+                Log.d("MainActivity", "All permissions granted.")
+                if (!isServiceRunning) {
+                    toggleService() 
+                }
+            } else {
+                Snackbar.make(
+                    binding.root,
+                    "Permissions are required. Please grant them in app settings.",
+                    Snackbar.LENGTH_LONG
+                ).setAction("Settings") {
+                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    val uri = Uri.fromParts("package", packageName, null)
+                    intent.data = uri
+                    startActivity(intent)
+                }.show()
+            }
+            updateUI()
+        }
+
+    // Launcher for MediaProjection permission
+    private val mediaProjectionLauncher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            Log.d("MainActivity", "MediaProjection permission result received. Result code: ${result.resultCode}")
+            // THIS IS THE CORRECTED LOGIC:
+            if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+                Log.i("MainActivity", "MediaProjection permission granted. Sending data to service.")
+                val serviceIntent = Intent(this, AudioLoopService::class.java).apply {
+                    action = AudioLoopService.ACTION_SETUP_PROJECTION
+                    putExtra(AudioLoopService.EXTRA_RESULT_CODE, result.resultCode)
+                    putExtra(AudioLoopService.EXTRA_DATA_INTENT, result.data)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    startForegroundService(serviceIntent)
+                } else {
+                    startService(serviceIntent)
+                }
+            } else {
+                Log.w("MainActivity", "MediaProjection permission denied or cancelled.")
+                Snackbar.make(binding.root, "App selection cancelled or denied.", Snackbar.LENGTH_SHORT).show()
+            }
+            updateUI() 
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // TODO: Setup UI listeners for:
-        // 1. Start/Stop button to launch/stop AudioLoopService
-        // 2. App selection button to trigger MediaProjection screen capture prompt
-        // 3. Volume sliders for internal audio and microphone
-        // 4. Observe service status and update UI (status indicator, audio levels)
+        mediaProjectionManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+
+        setupUIListeners()
+        observeServiceStatus()
+        updateUI() 
+    }
+
+    private fun setupUIListeners() {
+        binding.buttonToggleService.setOnClickListener {
+            if (!checkPermissions()) {
+                Log.d("MainActivity", "Requesting audio/notification permissions for toggle service.")
+                requestPermissionsLauncher.launch(requiredPermissions)
+            } else {
+                toggleService()
+            }
+        }
+
+        binding.buttonSelectApp.setOnClickListener {
+            Log.d("MainActivity", "Select App button clicked.")
+            if (!isServiceRunning) {
+                 Snackbar.make(binding.root, "Please start the loopback service first.", Snackbar.LENGTH_SHORT).show()
+                 return@setOnClickListener
+            }
+            mediaProjectionLauncher.launch(mediaProjectionManager.createScreenCaptureIntent())
+        }
+    }
+
+    private fun toggleService() {
+        val serviceIntent = Intent(this, AudioLoopService::class.java)
+        if (isServiceRunning) {
+            Log.d("MainActivity", "Attempting to stop service.")
+            serviceIntent.action = AudioLoopService.ACTION_STOP_SERVICE
+            startService(serviceIntent)
+        } else {
+            Log.d("MainActivity", "Attempting to start service.")
+            serviceIntent.action = AudioLoopService.ACTION_START_SERVICE
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(serviceIntent)
+            } else {
+                startService(serviceIntent)
+            }
+        }
+    }
+
+    private fun observeServiceStatus() {
+        AudioLoopService.isRunning.observe(this) { running ->
+            isServiceRunning = running
+            Log.d("MainActivity", "Service running state updated via LiveData: $isServiceRunning")
+            updateUI()
+        }
+    }
+
+    private fun updateUI() {
+        val projectionActive = AudioLoopService.isProjectionSetup() 
+        Log.d("MainActivity", "Updating UI. Service running: $isServiceRunning, Projection Active in Service: $projectionActive")
+        binding.buttonToggleService.text = if (isServiceRunning) "Stop Loopback" else "Start Loopback"
+
+        var statusText = "Status: ${if (isServiceRunning) "Active" else "Inactive"}"
+        if (isServiceRunning && projectionActive) {
+            statusText += " (App Selected for Capture)"
+        } else if (isServiceRunning && !projectionActive){
+            statusText += " (App Selection Pending)"
+        }
+        binding.textViewStatus.text = statusText
+
+        binding.buttonSelectApp.isEnabled = isServiceRunning
+    }
+
+    private fun checkPermissions(): Boolean {
+        return requiredPermissions.all {
+            ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isServiceRunning = AudioLoopService.isRunning.value ?: false
+        updateUI()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("MainActivity", "onDestroy called.")
     }
 }
+

--- a/app/src/main/java/com/audioloop/audioloop/MainApplication.kt
+++ b/app/src/main/java/com/audioloop/audioloop/MainApplication.kt
@@ -1,0 +1,12 @@
+package com.audioloop.audioloop
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // You can add any application-specific initialization here if needed.
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,10 +11,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Start Loopback"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/text_view_status"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"/>
 
     <TextView
         android:id="@+id/text_view_status"
@@ -25,14 +26,28 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Medium"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/button_toggle_service" />
+        app:layout_constraintTop_toBottomOf="@+id/button_toggle_service"
+        app:layout_constraintBottom_toTopOf="@+id/button_select_app"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_select_app"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Select App to Capture"
+        app:layout_constraintTop_toBottomOf="@+id/text_view_status"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/label_internal_audio" />
 
     <TextView
         android:id="@+id/label_internal_audio"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
         android:layout_marginBottom="4dp"
         android:text="Internal Audio Volume"
+        app:layout_constraintTop_toBottomOf="@+id/button_select_app"
         app:layout_constraintBottom_toTopOf="@+id/slider_internal_audio"
         app:layout_constraintStart_toStartOf="@+id/slider_internal_audio" />
 


### PR DESCRIPTION
Add comprehensive runtime permission handling for RECORD_AUDIO and
POST_NOTIFICATIONS (on Android T+), alongside user-facing guidance
via Snackbar directing to app settings when permissions are denied.

Introduce MediaProjectionManager and an ActivityResultLauncher to
request and handle MediaProjection permission. On successful grant,
send the projection result Intent and code to AudioLoopService using
ACTION_SETUP_PROJECTION; start service as a foreground service on
O+.

Add UI wiring: setup button listeners for toggling service and
selecting app, a permissions request launcher, and a media-projection
launcher. Track service running state with isServiceRunning and call
updateUI() after permission and projection results to refresh UI.

Improve logging for permission and projection flows to aid debugging.