### PR TITLE
fix(audio): enforce mediaProjection and update running state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,53 @@
-# AudioLoop: Mix and Share Audio on Android
+## Updated `README.md`
 
-AudioLoop is an open-source Android application designed to capture, mix, and share audio between apps. Imagine playing a YouTube video's audio into a live Twitter Space or a conference call, right from your phone. This project aims to make that possible through an intuitive floating widget.
 
-## The Goal
+# AudioLoop: A Floating Audio Mixer for Android
 
-Our vision is a simple, movable, on-screen widget that lets you:
+AudioLoop is an open-source Android application that operates as a **floating, on-screen gadget** for capturing, mixing, and sharing audio between apps. Imagine seamlessly piping a YouTube video's audio into a live conference call or a social audio room, all from a discreet, movable widget on your screen.
 
-1.  **Capture App Audio:** Stream the sound output from an app like YouTube or a music player.
-2.  **Mix with Microphone:** Simultaneously capture your voice from the device's microphone.
+## The Vision
+
+Our goal is to create a simple, intuitive, and movable floating widget that puts powerful audio mixing controls at your fingertips. This gadget will allow you to:
+
+1.  **Capture App Audio:** Stream the sound output from any application, like a podcast player or a video.
+2.  **Mix with Microphone:** Simultaneously record your voice from the device's microphone.
 3.  **Share Everywhere:** Use this combined audio stream as your input in other applications, such as meeting apps (Zoom, Google Meet) or social audio platforms (Twitter Spaces).
 
-## How It Works & The Challenges
+## How It Works & The Core Challenge
 
-While the goal is simple, Android's security model presents a significant challenge.
+The user experience is now centered around a **persistent floating widget** that stays on top of other apps. While the user-facing design is simple, Android's security model presents a significant challenge to our sharing goal.
 
-### What's Achievable Now
+### What's Achievable
 
-*   **App Audio Capture:** We can successfully capture the audio output from other applications.
-*   **Microphone Input:** We can add functionality to record from the microphone at the same time.
-*   **Audio Mixing:** The captured app audio and microphone audio can be mixed together into a single stream within AudioLoop.
+* **Floating UI:** The app is now a floating gadget, thanks to the "Draw over other apps" permission.
+* **App Audio Capture:** We can successfully capture the audio output from other applications.
+* **Microphone Input:** We can add functionality to record from the microphone at the same time.
+* **Real-time Mixing:** The captured app audio and microphone audio can be mixed together into a single, real-time stream within AudioLoop.
 
-### The Core Challenge: Sharing the Mix
+### The Problem: The "Virtual Microphone"
 
 Directly feeding this mixed audio into another app (like Twitter Spaces) as a "virtual microphone" is not possible for a standard Android app due to OS security and sandboxing limitations. Apps like Zoom or Twitter Spaces are hard-wired to use the physical microphone and don't allow selecting a different audio source.
 
 **The Workaround:**
-The only way for a standard app to achieve a similar result is indirectly:
+The only viable method for a standard app to share audio with a meeting app is indirectly:
 1.  AudioLoop plays the mixed audio (app sound + your voice) out loud through the phone's speaker.
 2.  The other app (e.g., Twitter Spaces) listens with the physical microphone and picks up the sound from the speaker.
 
 **Limitations of this approach:**
-*   **Echo/Feedback:** Can occur if you aren't using headphones for the meeting audio.
-*   **Reduced Quality:** The audio is being played and re-recorded, which degrades its quality.
+* **Echo/Feedback:** Can occur if you aren't using headphones to listen to the meeting audio.
+* **Reduced Quality:** The sound is being played and re-recorded, which naturally degrades its quality.
 
 ## Project Status & Next Steps
 
-This project is currently in active development. Given the platform constraints, we are focusing on building a powerful local audio mixing tool first.
+This project is in active development, focusing on building a robust local audio mixing tool with a polished floating user interface.
 
 Our immediate next steps are:
-1.  **Add Microphone Recording:** Implement simultaneous recording from the device microphone.
-2.  **Implement Audio Mixing:** Create a mixer to combine the app and microphone audio streams in real-time.
-3.  **Playback the Mix:** Allow the user to hear the final mixed audio through their headphones or speakers.
+1.  **Build the Floating UI:** Implement the floating widget functionality, including the ability to move and expand it.
+2.  **Add Microphone Recording:** Integrate real-time audio capture from the device microphone.
+3.  **Implement Audio Mixing:** Create a mixer to combine the app and microphone audio streams in real-time.
+4.  **Local Playback:** Allow the user to hear the final mixed audio through their headphones or speakers, a key feature for the workaround.
 
-This will provide a solid foundation and a useful tool for local recording and mixing, as we continue to explore the best ways to share the audio with other apps.
+This will provide a solid foundation and a useful tool for local recording and mixing, as we continue to explore the best ways to share the audio with other apps while navigating platform constraints.
 
 ## Contributing
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <!-- Required for Foreground Service notifications on Android 13+ -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
 
     <application
@@ -33,6 +34,10 @@
             android:name=".AudioLoopService"
             android:foregroundServiceType="microphone|mediaProjection"
             android:exported="false"/>
+
+        <service
+            android:name=".FloatingControlsService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
@@ -1,0 +1,165 @@
+package com.audioloop.audioloop
+
+import android.app.Service
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.IBinder
+import android.provider.Settings
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowManager
+import android.widget.ImageView
+import android.widget.Toast
+// import com.audioloop.audioloop.R // Already implicitly available by package
+
+class FloatingControlsService : Service() {
+
+    private lateinit var windowManager: WindowManager
+    private var floatingGadget: View? = null
+    private lateinit var params: WindowManager.LayoutParams
+    private var iconView: ImageView? = null
+
+    private var initialX: Int = 0
+    private var initialY: Int = 0
+    private var initialTouchX: Float = 0.0f
+    private var initialTouchY: Float = 0.0f
+
+    // Observe AudioLoopService.isRunning to update UI
+    private val audioLoopServiceRunningObserver = androidx.lifecycle.Observer<Boolean> {
+        isServiceRunning -> updateIcon(isServiceRunning)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
+            // This service should ideally not be started if permission is not granted.
+            // MainActivity should handle this check before starting the service.
+            Toast.makeText(this, "Overlay permission not granted", Toast.LENGTH_LONG).show()
+            stopSelf()
+            return
+        }
+
+        windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+
+        val inflater = getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        floatingGadget = inflater.inflate(R.layout.floating_gadget, null)
+        iconView = floatingGadget?.findViewById<ImageView>(R.id.floating_widget_icon)
+
+        val layoutFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        } else {
+            @Suppress("DEPRECATION")
+            WindowManager.LayoutParams.TYPE_PHONE
+        }
+
+        params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            layoutFlag,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            PixelFormat.TRANSLUCENT
+        )
+
+        params.gravity = Gravity.TOP or Gravity.START
+        params.x = 0
+        params.y = 100 // Initial position
+
+        try {
+            windowManager.addView(floatingGadget, params)
+        } catch (e: Exception) {
+            // Handle cases where window manager might fail (e.g. after screen rotation if not handled)
+            stopSelf()
+            return
+        }
+
+        setupTouchListener()
+        setupClickListener()
+
+        // Observe the LiveData from AudioLoopService
+        // We need a way to get the main Looper for LiveData observation if this service is not on main thread
+        // However, Service lifecycle methods are called on the main thread by default.
+        AudioLoopService.isRunning.observeForever(audioLoopServiceRunningObserver)
+        updateIcon(AudioLoopService.isRunning.value ?: false) // Initial icon state
+    }
+
+    private fun updateIcon(isRunning: Boolean) {
+        if (isRunning) {
+            iconView?.setImageResource(R.drawable.ic_stop) // Replace with your actual stop icon
+            iconView?.alpha = 1.0f // Full opacity when running
+        } else {
+            iconView?.setImageResource(R.drawable.ic_play) // Replace with your actual play icon
+            iconView?.alpha = 0.7f // Slightly dimmed when not running, to show it'''s active but pausable
+        }
+    }
+
+    private fun setupClickListener() {
+        iconView?.setOnClickListener {
+            val currentServiceState = AudioLoopService.isRunning.value ?: false
+            if (currentServiceState) {
+                sendActionToAudioLoopService(AudioLoopService.ACTION_PROCESS_AUDIO_STOP)
+            } else {
+                if (AudioLoopService.isProjectionSetup()) {
+                    sendActionToAudioLoopService(AudioLoopService.ACTION_PROCESS_AUDIO_START)
+                } else {
+                    Toast.makeText(this, "Screen capture not set up. Please set up from the main app.", Toast.LENGTH_LONG).show()
+                    // Optionally, could try to bring MainActivity to front or send a signal
+                }
+            }
+        }
+    }
+
+    private fun sendActionToAudioLoopService(action: String) {
+        val serviceIntent = Intent(this, AudioLoopService::class.java)
+        serviceIntent.action = action
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent) // Ensure AudioLoopService also calls startForeground for its notification
+        } else {
+            startService(serviceIntent)
+        }
+    }
+
+    private fun setupTouchListener() {
+        floatingGadget?.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    initialX = params.x
+                    initialY = params.y
+                    initialTouchX = event.rawX
+                    initialTouchY = event.rawY
+                    true
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    params.x = initialX + (event.rawX - initialTouchX).toInt()
+                    params.y = initialY + (event.rawY - initialTouchY).toInt()
+                    try {
+                        windowManager.updateViewLayout(floatingGadget, params)
+                    } catch (e: Exception) {
+                        // Could happen if service is stopping/view removed
+                    }
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        floatingGadget?.let {
+            try {
+                windowManager.removeView(it)
+            } catch (e: Exception) {
+                // Handle if view already removed or window manager service not available
+            }
+        }
+        AudioLoopService.isRunning.removeObserver(audioLoopServiceRunningObserver)
+    }
+}

--- a/app/src/main/java/com/audioloop/audioloop/MainActivity.kt
+++ b/app/src/main/java/com/audioloop/audioloop/MainActivity.kt
@@ -5,29 +5,31 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.media.projection.MediaProjectionManager // Only MediaProjectionManager is needed here
+import android.media.projection.MediaProjectionManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.audioloop.audioloop.databinding.ActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
-import dagger.hilt.android.AndroidEntryPoint
+// import dagger.hilt.android.AndroidEntryPoint // Assuming Hilt is setup, keep if used
 
-@AndroidEntryPoint
+// @AndroidEntryPoint // Assuming Hilt is setup, keep if used
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
-    private var isServiceRunning = false // Tracks the service's LiveData state
+    private var isAudioLoopServiceRunning = false // Tracks AudioLoopService's LiveData state (processing or not)
+    private var isFloatingControlsServiceActive = false // Tracks if FloatingControlsService is supposed to be active
 
-    private lateinit var mediaProjectionManager: MediaProjectionManager // Correct
+    private lateinit var mediaProjectionManager: MediaProjectionManager
 
-    private val requiredPermissions = mutableListOf(
+    private val requiredSdkPermissions = mutableListOf(
         Manifest.permission.RECORD_AUDIO
     ).apply {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -35,31 +37,29 @@ class MainActivity : AppCompatActivity() {
         }
     }.toTypedArray()
 
-    private val requestPermissionsLauncher =
+    // Launcher for standard permissions (RECORD_AUDIO, POST_NOTIFICATIONS)
+    private val requestSdkPermissionsLauncher: ActivityResultLauncher<Array<String>> =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            var allPermissionsGranted = true
-            permissions.entries.forEach {
-                if (!it.value) {
-                    allPermissionsGranted = false
-                }
-            }
-
-            if (allPermissionsGranted) {
-                Log.d("MainActivity", "All permissions granted.")
-                if (!isServiceRunning) {
-                    toggleService() 
-                }
+            if (permissions.all { it.value }) {
+                Log.d(TAG, "All SDK permissions granted.")
+                // After SDK permissions, check for overlay permission to show controls
+                checkAndRequestOverlayPermissionForControls()
             } else {
-                Snackbar.make(
-                    binding.root,
-                    "Permissions are required. Please grant them in app settings.",
-                    Snackbar.LENGTH_LONG
-                ).setAction("Settings") {
-                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                    val uri = Uri.fromParts("package", packageName, null)
-                    intent.data = uri
-                    startActivity(intent)
-                }.show()
+                Log.w(TAG, "Not all SDK permissions were granted.")
+                Snackbar.make(binding.root, "Record Audio and Notification permissions are required.", Snackbar.LENGTH_LONG).show()
+            }
+            updateUI()
+        }
+
+    // Launcher for Overlay Permission
+    private val requestOverlayPermissionLauncher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ -> // Result isn'''t directly used, we re-check Settings.canDrawOverlays
+            if (Settings.canDrawOverlays(this)) {
+                Log.d(TAG, "Overlay permission granted after returning from settings.")
+                startFloatingControlsService()
+            } else {
+                Log.w(TAG, "Overlay permission was not granted after returning from settings.")
+                Snackbar.make(binding.root, "Overlay permission is needed to show floating controls.", Snackbar.LENGTH_SHORT).show()
             }
             updateUI()
         }
@@ -67,25 +67,25 @@ class MainActivity : AppCompatActivity() {
     // Launcher for MediaProjection permission
     private val mediaProjectionLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            Log.d("MainActivity", "MediaProjection permission result received. Result code: ${result.resultCode}")
-            // THIS IS THE CORRECTED LOGIC:
+            Log.d(TAG, "MediaProjection permission result. Code: ${result.resultCode}")
             if (result.resultCode == Activity.RESULT_OK && result.data != null) {
-                Log.i("MainActivity", "MediaProjection permission granted. Sending data to service.")
+                Log.i(TAG, "MediaProjection obtained. Sending to AudioLoopService.")
                 val serviceIntent = Intent(this, AudioLoopService::class.java).apply {
                     action = AudioLoopService.ACTION_SETUP_PROJECTION
                     putExtra(AudioLoopService.EXTRA_RESULT_CODE, result.resultCode)
                     putExtra(AudioLoopService.EXTRA_DATA_INTENT, result.data)
                 }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    startForegroundService(serviceIntent)
-                } else {
-                    startService(serviceIntent)
-                }
+                ContextCompat.startForegroundService(this, serviceIntent)
             } else {
-                Log.w("MainActivity", "MediaProjection permission denied or cancelled.")
-                Snackbar.make(binding.root, "App selection cancelled or denied.", Snackbar.LENGTH_SHORT).show()
+                Log.w(TAG, "MediaProjection permission denied or cancelled.")
+                Snackbar.make(binding.root, "Screen capture permission denied or cancelled.", Snackbar.LENGTH_SHORT).show()
+                // If projection fails, ensure AudioLoopService state reflects it'''s not running processing.
+                 val stopProcessingIntent = Intent(this, AudioLoopService::class.java).apply { 
+                    action = AudioLoopService.ACTION_PROCESS_AUDIO_STOP 
+                }
+                ContextCompat.startForegroundService(this, stopProcessingIntent)
             }
-            updateUI() 
+            updateUI() // UI should reflect projection status via AudioLoopService.isProjectionSetup()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -95,87 +95,136 @@ class MainActivity : AppCompatActivity() {
 
         mediaProjectionManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
 
+        // Start AudioLoopService in a "standby" mode to show notification and be ready for projection
+        // This ensures the service is active for projection setup even if controls are not yet shown.
+        val initialServiceIntent = Intent(this, AudioLoopService::class.java).apply {
+            action = AudioLoopService.ACTION_START_SERVICE
+        }
+        ContextCompat.startForegroundService(this, initialServiceIntent)
+
         setupUIListeners()
         observeServiceStatus()
-        updateUI() 
+        updateUI()
     }
 
     private fun setupUIListeners() {
+        // This button will now toggle the FloatingControlsService
         binding.buttonToggleService.setOnClickListener {
-            if (!checkPermissions()) {
-                Log.d("MainActivity", "Requesting audio/notification permissions for toggle service.")
-                requestPermissionsLauncher.launch(requiredPermissions)
+            if (isFloatingControlsServiceActive) {
+                stopFloatingControlsService()
             } else {
-                toggleService()
+                checkAndRequestSdkPermissionsForControls() // This will then chain to overlay permission
             }
         }
 
+        // This button is for initiating screen capture selection
         binding.buttonSelectApp.setOnClickListener {
-            Log.d("MainActivity", "Select App button clicked.")
-            if (!isServiceRunning) {
-                 Snackbar.make(binding.root, "Please start the loopback service first.", Snackbar.LENGTH_SHORT).show()
-                 return@setOnClickListener
+            if (!AudioLoopService.isProjectionSetup()) { // Or if you want to allow re-selection
+                 Log.d(TAG, "Requesting MediaProjection.")
+                 mediaProjectionLauncher.launch(mediaProjectionManager.createScreenCaptureIntent())
+            } else {
+                // Optionally allow re-selection or inform user it'''s already set up
+                 Snackbar.make(binding.root, "Screen capture already set up. Restart gadget to re-select.", Snackbar.LENGTH_LONG).show()
             }
-            mediaProjectionLauncher.launch(mediaProjectionManager.createScreenCaptureIntent())
+        }
+    }
+    
+    private fun checkAndRequestSdkPermissionsForControls() {
+        val allSdkGranted = requiredSdkPermissions.all {
+            ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
+        }
+        if (allSdkGranted) {
+            Log.d(TAG, "SDK permissions already granted. Checking overlay for controls.")
+            checkAndRequestOverlayPermissionForControls()
+        } else {
+            Log.d(TAG, "Requesting SDK permissions for controls.")
+            requestSdkPermissionsLauncher.launch(requiredSdkPermissions)
         }
     }
 
-    private fun toggleService() {
-        val serviceIntent = Intent(this, AudioLoopService::class.java)
-        if (isServiceRunning) {
-            Log.d("MainActivity", "Attempting to stop service.")
-            serviceIntent.action = AudioLoopService.ACTION_STOP_SERVICE
-            startService(serviceIntent)
+    private fun checkAndRequestOverlayPermissionForControls() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
+            Log.d(TAG, "Overlay permission not granted. Requesting...")
+            val intent = Intent(
+                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                Uri.parse("package:$packageName")
+            )
+            requestOverlayPermissionLauncher.launch(intent)
         } else {
-            Log.d("MainActivity", "Attempting to start service.")
-            serviceIntent.action = AudioLoopService.ACTION_START_SERVICE
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                startForegroundService(serviceIntent)
-            } else {
-                startService(serviceIntent)
-            }
+            Log.d(TAG, "Overlay permission already granted or not required. Starting floating controls.")
+            startFloatingControlsService()
         }
+    }
+
+    private fun startFloatingControlsService() {
+        if (!Settings.canDrawOverlays(this) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Log.w(TAG, "Attempted to start FloatingControlsService without overlay permission.")
+            Snackbar.make(binding.root, "Overlay permission is required first.", Snackbar.LENGTH_LONG).show()
+            return
+        }
+        Log.d(TAG, "Starting FloatingControlsService.")
+        val intent = Intent(this, FloatingControlsService::class.java)
+        startService(intent)
+        isFloatingControlsServiceActive = true
+        updateUI()
+    }
+
+    private fun stopFloatingControlsService() {
+        Log.d(TAG, "Stopping FloatingControlsService.")
+        val intent = Intent(this, FloatingControlsService::class.java)
+        stopService(intent)
+        isFloatingControlsServiceActive = false
+        // Also stop audio processing if floating controls are hidden
+        val stopProcessingIntent = Intent(this, AudioLoopService::class.java).apply { 
+            action = AudioLoopService.ACTION_PROCESS_AUDIO_STOP 
+        }
+        ContextCompat.startForegroundService(this, stopProcessingIntent)
+        updateUI()
     }
 
     private fun observeServiceStatus() {
         AudioLoopService.isRunning.observe(this) { running ->
-            isServiceRunning = running
-            Log.d("MainActivity", "Service running state updated via LiveData: $isServiceRunning")
+            isAudioLoopServiceRunning = running
+            Log.d(TAG, "AudioLoopService.isRunning state updated via LiveData: $isAudioLoopServiceRunning")
             updateUI()
         }
     }
 
     private fun updateUI() {
-        val projectionActive = AudioLoopService.isProjectionSetup() 
-        Log.d("MainActivity", "Updating UI. Service running: $isServiceRunning, Projection Active in Service: $projectionActive")
-        binding.buttonToggleService.text = if (isServiceRunning) "Stop Loopback" else "Start Loopback"
+        val projectionReady = AudioLoopService.isProjectionSetup()
+        Log.d(TAG, "Updating UI: AudioLoop Running: $isAudioLoopServiceRunning, Projection Ready: $projectionReady, Controls Active: $isFloatingControlsServiceActive")
 
-        var statusText = "Status: ${if (isServiceRunning) "Active" else "Inactive"}"
-        if (isServiceRunning && projectionActive) {
-            statusText += " (App Selected for Capture)"
-        } else if (isServiceRunning && !projectionActive){
-            statusText += " (App Selection Pending)"
-        }
+        binding.buttonToggleService.text = if (isFloatingControlsServiceActive) "Hide Floating Controls" else "Show Floating Controls"
+        
+        var statusText = "Gadget: ${if (isFloatingControlsServiceActive) "Shown" else "Hidden"}\n"
+        statusText += "Screen Capture: ${if (projectionReady) "Set" else "Not Set"}\n"
+        statusText += "Audio Loop: ${if (isAudioLoopServiceRunning) "ACTIVE" else "INACTIVE"}"
+        
         binding.textViewStatus.text = statusText
-
-        binding.buttonSelectApp.isEnabled = isServiceRunning
-    }
-
-    private fun checkPermissions(): Boolean {
-        return requiredPermissions.all {
-            ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
-        }
+        binding.buttonSelectApp.isEnabled = !projectionReady // Enable if projection not yet set
     }
 
     override fun onResume() {
         super.onResume()
-        isServiceRunning = AudioLoopService.isRunning.value ?: false
+        // Reflect the current state accurately, esp. if returning from settings for overlay perm
+        isAudioLoopServiceRunning = AudioLoopService.isRunning.value ?: false 
+        // isFloatingControlsServiceActive // This is maintained by start/stopFloatingControlsService logic
         updateUI()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.d("MainActivity", "onDestroy called.")
+        Log.d(TAG, "MainActivity onDestroy.")
+        // Option: if floating controls are active, maybe stop them to avoid leaks if not intended to persist beyond MainActivity.
+        // However, typically a floating gadget is meant to persist, so user explicitly hides it.
+        // If you want to ensure AudioLoopService fully stops when MainActivity is destroyed:
+        // val serviceIntent = Intent(this, AudioLoopService::class.java)
+        // serviceIntent.action = AudioLoopService.ACTION_STOP_SERVICE
+        // ContextCompat.startForegroundService(this, serviceIntent)
+        // stopFloatingControlsService() // also hide controls
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }
-

--- a/app/src/main/res/layout/floating_gadget.xml
+++ b/app/src/main/res/layout/floating_gadget.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/floating_widget_icon"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:src="@mipmap/ic_launcher_round"
+        android:contentDescription="AudioLoop Control" />
+
+</FrameLayout>


### PR DESCRIPTION
Ensure startAudioProcessing properly handles missing MediaProjection
and updates the _isRunning LiveData on failure and success.

- Check currentMediaProjection before attempting audio playback capture
  and log an error / set _isRunning to false when absent.
- Set _isRunning to false whenever permission, audio focus, or setup
  failures occur (early returns and after resource setup failure).
- Move and simplify app audio capture setup to assume non-null
  currentMediaProjection when checked, improving readability.
- Post _isRunning = true after successfully starting recording and
  playback so observers reflect the true running state.

This prevents the service from appearing active when audio setup fails
or MediaProjection hasn't been established.