### PR TITLE
feat(floating): add notification, broadcast handling and touch support

### DIFF
--- a/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
@@ -9,14 +9,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.media.AudioAttributes
-import android.media.AudioFocusRequest
-import android.media.AudioManager
-import android.media.AudioFormat
-import android.media.AudioPlaybackCaptureConfiguration
-import android.media.AudioRecord
-import android.media.AudioTrack
-import android.media.MediaRecorder
+import android.media.*
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
 import android.os.Build
@@ -27,6 +20,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -36,7 +30,7 @@ class AudioLoopService : Service() {
     private var notificationManager: NotificationManager? = null
     private lateinit var audioManager: AudioManager
 
-    private var appAudioRecord: AudioRecord? = null // Will be read but ignored for playback
+    private var appAudioRecord: AudioRecord? = null
     @Volatile private var isCapturingAppAudio: Boolean = false
     private var micAudioRecord: AudioRecord? = null
     @Volatile private var isCapturingMicAudio: Boolean = false
@@ -51,7 +45,6 @@ class AudioLoopService : Service() {
     private val AUDIO_FORMAT_ENCODING = AudioFormat.ENCODING_PCM_16BIT
     private val APP_CHANNEL_CONFIG_IN = AudioFormat.CHANNEL_IN_STEREO
     private val MIC_CHANNEL_CONFIG_IN = AudioFormat.CHANNEL_IN_MONO
-    private val MIC_BYTES_PER_FRAME = 2 // Mono PCM16
     private val PLAYBACK_CHANNEL_CONFIG_OUT = AudioFormat.CHANNEL_OUT_STEREO
     private val PLAYBACK_BYTES_PER_FRAME = 4 // Stereo PCM16
 
@@ -60,307 +53,233 @@ class AudioLoopService : Service() {
         .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
         .build()
 
+    private val runningStateObserver = Observer<Boolean> { running ->
+        Log.d(TAG, "AudioLoopService: _isRunning LiveData changed to: $running. Broadcasting update to FloatingControlsService.")
+        val updateIntent = Intent(FloatingControlsService.ACTION_UPDATE_ICON)
+        updateIntent.putExtra(FloatingControlsService.EXTRA_IS_RUNNING, running)
+        sendBroadcast(updateIntent)
+    }
+
     override fun onCreate() {
         super.onCreate()
-        Log.d(TAG, "Service onCreate (Boosted Mic Test)")
+        Log.d(TAG, "AudioLoopService: onCreate")
         mediaProjectionManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
         notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        _isRunning.postValue(false)
+        _isRunning.postValue(false) // Initial state
+        _isRunning.observeForever(runningStateObserver) // Start observing
         setupAudioFocusListener()
     }
 
-    private fun setupAudioFocusListener() {
+    private fun setupAudioFocusListener() { /* ... same as before ... */
         onAudioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
-            val action = when (focusChange) {
-                AudioManager.AUDIOFOCUS_GAIN -> "AUDIOFOCUS_GAIN"
-                AudioManager.AUDIOFOCUS_LOSS -> "AUDIOFOCUS_LOSS"
-                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "AUDIOFOCUS_LOSS_TRANSIENT"
-                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK"
-                else -> "Unknown focus change: $focusChange"
-            }
-            Log.d(TAG, "BoostedMicTest: $action")
+            Log.d(TAG, "AudioLoopService: AudioFocusChanged: $focusChange")
             shouldBePlayingBasedOnFocus = focusChange == AudioManager.AUDIOFOCUS_GAIN
             if (shouldBePlayingBasedOnFocus && audioTrack?.playState == AudioTrack.PLAYSTATE_PAUSED) audioTrack?.play()
             else if (!shouldBePlayingBasedOnFocus && audioTrack?.playState == AudioTrack.PLAYSTATE_PLAYING) audioTrack?.pause()
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            audioFocusRequestForListener = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-                .setAudioAttributes(playbackAttributes).setAcceptsDelayedFocusGain(true)
-                .setOnAudioFocusChangeListener(onAudioFocusChangeListener).build()
-            audioManager.requestAudioFocus(audioFocusRequestForListener!!)
-        } else {
-            @Suppress("DEPRECATION")
-            audioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-        }
-        Log.d(TAG, "BoostedMicTest: Registered 'passive' audio focus listener.")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { audioFocusRequestForListener = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK).setAudioAttributes(playbackAttributes).setAcceptsDelayedFocusGain(true).setOnAudioFocusChangeListener(onAudioFocusChangeListener).build(); audioManager.requestAudioFocus(audioFocusRequestForListener!!)
+        } else { @Suppress("DEPRECATION") audioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK) }
     }
+    private fun requestAudioFocus(): Boolean { /* ... same ... */ Log.d(TAG, "AudioLoopService: Requesting AudioFocus"); shouldBePlayingBasedOnFocus = true; return true }
+    private fun abandonAudioFocus() { /* ... same ... */ Log.d(TAG, "AudioLoopService: Abandoning AudioFocus"); if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { audioFocusRequestForListener?.let { audioManager.abandonAudioFocusRequest(it) } } else { @Suppress("DEPRECATION") audioManager.abandonAudioFocus(onAudioFocusChangeListener) } }
 
-    private fun requestAudioFocus(): Boolean { shouldBePlayingBasedOnFocus = true; return true }
-    private fun abandonAudioFocus() { if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { audioFocusRequestForListener?.let { audioManager.abandonAudioFocusRequest(it) } } else { @Suppress("DEPRECATION") audioManager.abandonAudioFocus(onAudioFocusChangeListener) }; Log.d(TAG, "BoostedMicTest: Passive listener abandoned.") }
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
     private fun startAudioProcessing(): Boolean {
-        Log.d(TAG, "BoostedMicTest: Attempting audio processing (Boosted Mic to Track)...")
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) { Log.e(TAG, "BoostedMicTest: RECORD_AUDIO permission not granted."); _isRunning.postValue(false); return false }
-        if (currentMediaProjection == null) { Log.e(TAG, "BoostedMicTest: MediaProjection is not set up.");  _isRunning.postValue(false); return false }
-        if (audioProcessingThread?.isAlive == true) { Log.w(TAG, "BoostedMicTest: Thread already running."); return true }
+        Log.d(TAG, "AudioLoopService: Attempting startAudioProcessing...")
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) { Log.e(TAG, "AudioLoopService: RECORD_AUDIO permission not granted."); _isRunning.postValue(false); return false }
+        if (audioProcessingThread?.isAlive == true) { Log.w(TAG, "AudioLoopService: Thread already running."); return true }
         if (!requestAudioFocus()) { _isRunning.postValue(false); return false }
 
-        var appRecordOk = true
-        var micRecordOk = false
-        var audioTrackOk = false
-        var appRecordBufferSizeInBytes = 0
-        var micRecordBufferSizeInBytes = 0
-        var trackBufferSizeInBytes = 0
+        var appRecordOk = true; var micRecordOk = false; var audioTrackOk = false
+        var appRecordBufferSizeInBytes = 0; var micRecordBufferSizeInBytes = 0; var trackBufferSizeInBytes = 0
 
-        // App audio capture setup (optional, based on currentMediaProjection)
-        val arFormat = AudioFormat.Builder().setEncoding(AUDIO_FORMAT_ENCODING).setSampleRate(SAMPLE_RATE).setChannelMask(APP_CHANNEL_CONFIG_IN).build()
-        val captureConfig = AudioPlaybackCaptureConfiguration.Builder(currentMediaProjection!!)
-            .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
-            .addMatchingUsage(AudioAttributes.USAGE_GAME)
-            .build()
-        appRecordBufferSizeInBytes = AudioRecord.getMinBufferSize(SAMPLE_RATE, APP_CHANNEL_CONFIG_IN, AUDIO_FORMAT_ENCODING) * 2
-        if (appRecordBufferSizeInBytes > 0) {
-            try {
-                appAudioRecord = AudioRecord.Builder().setAudioFormat(arFormat).setAudioPlaybackCaptureConfig(captureConfig).setBufferSizeInBytes(appRecordBufferSizeInBytes).build()
-                if (appAudioRecord?.state != AudioRecord.STATE_INITIALIZED) { Log.e(TAG, "BoostedMicTest: App AR init failed."); appRecordOk = false }
-            } catch (e: Exception) { Log.e(TAG, "BoostedMicTest: App AR creation ex", e); appRecordOk = false }
-        } else { Log.e(TAG, "BoostedMicTest: App AR invalid buffer size"); appRecordOk = false }
+        if (currentMediaProjection != null) {
+            val arFormat = AudioFormat.Builder().setEncoding(AUDIO_FORMAT_ENCODING).setSampleRate(SAMPLE_RATE).setChannelMask(APP_CHANNEL_CONFIG_IN).build()
+            val captureConfig = AudioPlaybackCaptureConfiguration.Builder(currentMediaProjection!!).addMatchingUsage(AudioAttributes.USAGE_MEDIA).addMatchingUsage(AudioAttributes.USAGE_GAME).build()
+            appRecordBufferSizeInBytes = AudioRecord.getMinBufferSize(SAMPLE_RATE, APP_CHANNEL_CONFIG_IN, AUDIO_FORMAT_ENCODING) * 2
+            if (appRecordBufferSizeInBytes > 0) { try { appAudioRecord = AudioRecord.Builder().setAudioFormat(arFormat).setAudioPlaybackCaptureConfig(captureConfig).setBufferSizeInBytes(appRecordBufferSizeInBytes).build(); if (appAudioRecord?.state != AudioRecord.STATE_INITIALIZED) { Log.e(TAG, "AudioLoopService: App AR init failed."); appRecordOk = false } else { appRecordOk = true; } } catch (e: Exception) { Log.e(TAG, "AudioLoopService: App AR creation ex", e); appRecordOk = false } } else { Log.e(TAG, "AudioLoopService: App AR invalid buffer size"); appRecordOk = false }
+        } else { Log.w(TAG, "AudioLoopService: MediaProjection not available. App audio capture skipped."); appAudioRecord = null; appRecordOk = true; }
 
         val micFormat = AudioFormat.Builder().setEncoding(AUDIO_FORMAT_ENCODING).setSampleRate(SAMPLE_RATE).setChannelMask(MIC_CHANNEL_CONFIG_IN).build()
         micRecordBufferSizeInBytes = AudioRecord.getMinBufferSize(SAMPLE_RATE, MIC_CHANNEL_CONFIG_IN, AUDIO_FORMAT_ENCODING) * 2
-        if (micRecordBufferSizeInBytes > 0) {
-            try {
-                micAudioRecord = AudioRecord.Builder().setAudioSource(MediaRecorder.AudioSource.MIC).setAudioFormat(micFormat).setBufferSizeInBytes(micRecordBufferSizeInBytes).build()
-                if (micAudioRecord?.state == AudioRecord.STATE_INITIALIZED) micRecordOk = true
-                else Log.e(TAG, "BoostedMicTest: Mic AR init failed.")
-            } catch (e: Exception) { Log.e(TAG, "BoostedMicTest: Mic AR creation ex", e) }
-        } else Log.e(TAG, "BoostedMicTest: Mic AR invalid buffer size")
+        if (micRecordBufferSizeInBytes > 0) { try { micAudioRecord = AudioRecord.Builder().setAudioSource(MediaRecorder.AudioSource.MIC).setAudioFormat(micFormat).setBufferSizeInBytes(micRecordBufferSizeInBytes).build(); if (micAudioRecord?.state == AudioRecord.STATE_INITIALIZED) micRecordOk = true else Log.e(TAG, "AudioLoopService: Mic AR init failed.") } catch (e: Exception) { Log.e(TAG, "AudioLoopService: Mic AR creation ex", e) } } else Log.e(TAG, "AudioLoopService: Mic AR invalid buffer size")
 
         val trackFormat = AudioFormat.Builder().setEncoding(AUDIO_FORMAT_ENCODING).setSampleRate(SAMPLE_RATE).setChannelMask(PLAYBACK_CHANNEL_CONFIG_OUT).build()
         trackBufferSizeInBytes = AudioTrack.getMinBufferSize(SAMPLE_RATE, PLAYBACK_CHANNEL_CONFIG_OUT, AUDIO_FORMAT_ENCODING) * 2
-        if (trackBufferSizeInBytes > 0) {
-            try {
-                audioTrack = AudioTrack.Builder().setAudioAttributes(playbackAttributes).setAudioFormat(trackFormat).setBufferSizeInBytes(trackBufferSizeInBytes).setTransferMode(AudioTrack.MODE_STREAM).build()
-                if (audioTrack?.state == AudioTrack.STATE_INITIALIZED) audioTrackOk = true
-                else Log.e(TAG, "BoostedMicTest: AT init failed.")
-            } catch (e: Exception) { Log.e(TAG, "BoostedMicTest: AT creation ex", e) }
-        } else Log.e(TAG, "BoostedMicTest: AT invalid buffer size")
+        if (trackBufferSizeInBytes > 0) { try { audioTrack = AudioTrack.Builder().setAudioAttributes(playbackAttributes).setAudioFormat(trackFormat).setBufferSizeInBytes(trackBufferSizeInBytes).setTransferMode(AudioTrack.MODE_STREAM).build(); if (audioTrack?.state == AudioTrack.STATE_INITIALIZED) audioTrackOk = true else Log.e(TAG, "AudioLoopService: AT init failed.") } catch (e: Exception) { Log.e(TAG, "AudioLoopService: AT creation ex", e) } } else Log.e(TAG, "AudioLoopService: AT invalid buffer size")
 
-        if (! (appRecordOk && micRecordOk && audioTrackOk) ) {
-            Log.e(TAG, "BoostedMicTest: Audio setup failed. AppRec:$appRecordOk, MicRec:$micRecordOk, Track:$audioTrackOk")
+        if (!((appRecordOk && currentMediaProjection != null) || micRecordOk) || !audioTrackOk) {
+            Log.e(TAG, "AudioLoopService: Audio setup failed. AppRec:$appRecordOk (Proj: ${currentMediaProjection!=null}), MicRec:$micRecordOk, Track:$audioTrackOk")
             appAudioRecord?.release(); appAudioRecord = null; micAudioRecord?.release(); micAudioRecord = null; audioTrack?.release(); audioTrack = null
-            _isRunning.postValue(false)
-            return false
+            _isRunning.postValue(false); return false
         }
 
-        isCapturingAppAudio = appAudioRecord != null
-        isCapturingMicAudio = micAudioRecord != null
+        isCapturingAppAudio = appAudioRecord != null && appRecordOk
+        isCapturingMicAudio = micAudioRecord != null && micRecordOk
 
-        appAudioRecord?.startRecording() // Data will be drained
-        micAudioRecord?.startRecording()
+        if (!isCapturingAppAudio && !isCapturingMicAudio) { Log.e(TAG, "AudioLoopService: No audio source could be initialized."); _isRunning.postValue(false); return false }
+        
+        if (isCapturingAppAudio) appAudioRecord?.startRecording()
+        if (isCapturingMicAudio) micAudioRecord?.startRecording()
         audioTrack?.play()
-        Log.d(TAG, "BoostedMicTest: Sources and track started (Boosted Mic to Track Test).")
-        _isRunning.postValue(true)
+        Log.d(TAG, "AudioLoopService: Sources (App: $isCapturingAppAudio, Mic: $isCapturingMicAudio) and track started.")
+        _isRunning.postValue(true) // This will trigger the observer to broadcast
 
-        audioProcessingThread = Thread {
-            val appBuf = if (appAudioRecord != null && appRecordBufferSizeInBytes > 0) ByteBuffer.allocateDirect(appRecordBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
-            val micBuf = if (micAudioRecord != null && micRecordBufferSizeInBytes > 0) ByteBuffer.allocateDirect(micRecordBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
-            val playbackBuf = if(trackBufferSizeInBytes > 0) ByteBuffer.allocateDirect(trackBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
+        audioProcessingThread = Thread { /* ... audio processing loop ... */
+            Log.d(TAG, "AudioLoopService: Audio processing thread started.")
+             val appBuf = if (isCapturingAppAudio && appAudioRecord != null && appRecordBufferSizeInBytes > 0) ByteBuffer.allocateDirect(appRecordBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
+            val micBuf = if (isCapturingMicAudio && micAudioRecord != null && micRecordBufferSizeInBytes > 0) ByteBuffer.allocateDirect(micRecordBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
+            val playbackBuf = if(audioTrackOk && trackBufferSizeInBytes > 0) ByteBuffer.allocateDirect(trackBufferSizeInBytes).order(ByteOrder.LITTLE_ENDIAN) else null
 
-            if (playbackBuf == null) { Log.e(TAG, "BoostedMicTest: Failed to allocate playbackBuf."); _isRunning.postValue(false); return@Thread }
-            var logCounter = 0
+            if (playbackBuf == null) { Log.e(TAG, "AudioLoopService: Failed to allocate playbackBuf."); _isRunning.postValue(false); return@Thread }
+            
+            val appIsStereo = APP_CHANNEL_CONFIG_IN == AudioFormat.CHANNEL_IN_STEREO
 
-            while (isCapturingMicAudio && shouldBePlayingBasedOnFocus && audioTrack?.playState == AudioTrack.PLAYSTATE_PLAYING) {
+            while ((isCapturingAppAudio || isCapturingMicAudio) && shouldBePlayingBasedOnFocus && audioTrack?.playState == AudioTrack.PLAYSTATE_PLAYING && _isRunning.value == true) { 
+                var appBytesRead = 0
                 if (isCapturingAppAudio && appAudioRecord != null && appBuf != null) {
-                    appBuf.clear(); appAudioRecord!!.read(appBuf, appBuf.capacity()) // Drain app audio
+                    appBuf.clear(); appBytesRead = appAudioRecord!!.read(appBuf, appBuf.capacity())
+                    if (appBytesRead < 0) { Log.e(TAG, "App audio read error: $appBytesRead"); isCapturingAppAudio = false; } else if (appBytesRead > 0) appBuf.flip()
                 }
-
-                var micBytes = 0
+                var micBytesRead = 0
                 if (isCapturingMicAudio && micAudioRecord != null && micBuf != null) {
-                    micBuf.clear()
-                    micBytes = micAudioRecord!!.read(micBuf, micBuf.capacity())
-                    if (micBytes < 0) { Log.e(TAG, "BoostedMicTest: Mic read error: $micBytes"); isCapturingMicAudio = false }
-                    else if (micBytes > 0) micBuf.flip()
+                    micBuf.clear(); micBytesRead = micAudioRecord!!.read(micBuf, micBuf.capacity())
+                    if (micBytesRead < 0) { Log.e(TAG, "Mic audio read error: $micBytesRead"); isCapturingMicAudio = false; } else if (micBytesRead > 0) micBuf.flip()
                 }
-
-                if (micBytes <= 0) {
-                    if (!isCapturingMicAudio) break
-                    try { Thread.sleep(10) } catch (e: InterruptedException) { Thread.currentThread().interrupt(); break }
-                    continue
+                if ((!isCapturingAppAudio || appBytesRead <= 0) && (!isCapturingMicAudio || micBytesRead <= 0)) {
+                    if (!isCapturingAppAudio && !isCapturingMicAudio) break 
+                    try { Thread.sleep(10) } catch (e: InterruptedException) { Thread.currentThread().interrupt(); break }; continue
                 }
-
                 playbackBuf.clear()
-                val framesToProcess = playbackBuf.capacity() / PLAYBACK_BYTES_PER_FRAME
-
-                for (i in 0 until framesToProcess) {
-                    var micM: Short = 0
-                    var originalMicM : Short = 0
-                    if (micBuf != null && micBuf.remaining() >= MIC_BYTES_PER_FRAME) {
-                        originalMicM = micBuf.short
-                        micM = originalMicM
-                    } else {
-                        playbackBuf.limit(playbackBuf.position()); break
-                    }
-
-                    val boostedMicSample = (micM.toInt() * 8).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-
-                    if (logCounter % 200 == 0 && originalMicM != 0.toShort()) { // Log non-zero original samples occasionally
-                        Log.d(TAG, "BoostedMicTest: MicSample Original: $originalMicM, Boosted: $boostedMicSample")
-                    }
-
-                    playbackBuf.putShort(boostedMicSample)
-                    playbackBuf.putShort(boostedMicSample)
+                val framesInPlaybackBuf = playbackBuf.capacity() / PLAYBACK_BYTES_PER_FRAME
+                for (i in 0 until framesInPlaybackBuf) {
+                    var appLeftShort: Short = 0; var appRightShort: Short = 0; var micMonoShort: Short = 0
+                    var appSampleAvailable = false
+                    if (isCapturingAppAudio && appBuf != null && appBytesRead > 0 && appBuf.remaining() >= (if (appIsStereo) 4 else 2) ) { appLeftShort = appBuf.short; appRightShort = if (appIsStereo) appBuf.short else appLeftShort; appSampleAvailable = true; }
+                    var micSampleAvailable = false
+                    if (isCapturingMicAudio && micBuf != null && micBytesRead > 0 && micBuf.remaining() >= 2 ) { micMonoShort = micBuf.short; micSampleAvailable = true; }
+                    if (!appSampleAvailable && !micSampleAvailable) { playbackBuf.limit(playbackBuf.position()); break; }
+                    val boostedMicInt = if (micSampleAvailable) (micMonoShort.toInt() * MIC_GAIN_FACTOR).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()) else 0
+                    val finalLeft = if (appSampleAvailable) (appLeftShort.toInt() + boostedMicInt).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort() else boostedMicInt.toShort()
+                    val finalRight = if (appSampleAvailable) (appRightShort.toInt() + boostedMicInt).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort() else boostedMicInt.toShort()
+                    playbackBuf.putShort(finalLeft); playbackBuf.putShort(finalRight)
                 }
-                logCounter++
-
                 playbackBuf.flip()
-                if (playbackBuf.remaining() > 0) {
-                    audioTrack?.write(playbackBuf, playbackBuf.remaining(), AudioTrack.WRITE_BLOCKING)
-                }
+                if (playbackBuf.remaining() > 0) { val written = audioTrack?.write(playbackBuf, playbackBuf.remaining(), AudioTrack.WRITE_BLOCKING); if (written != null && written < 0) Log.e(TAG, "AudioTrack write error: $written") }
             }
-            Log.d(TAG, "BoostedMicTest: Audio processing thread finished.")
-            // Ensure isRunning state is updated when thread stops for any reason other than explicit stop command
-            if (_isRunning.value == true && !(actionBeingProcessed == ACTION_PROCESS_AUDIO_STOP || actionBeingProcessed == ACTION_STOP_SERVICE) ) {
+            Log.d(TAG, "AudioLoopService: Audio processing thread finished. _isRunning.value: ${_isRunning.value}")
+            if (_isRunning.value == true && !(isCapturingAppAudio || isCapturingMicAudio)) {
                  _isRunning.postValue(false)
             }
-        }
-        audioProcessingThread?.name = "BoostedMicTestThread"
-        audioProcessingThread?.start()
+        }.apply { name = "AudioLoopMixThread"; start() }
         return true
     }
 
     private fun stopAudioProcessing() {
-        Log.d(TAG, "BoostedMicTest: Stopping audio processing...")
-        isCapturingAppAudio = false; isCapturingMicAudio = false; // shouldBePlayingBasedOnFocus = false; // Keep focus state for passive listener
-        if (audioProcessingThread?.isAlive == true) { try { audioProcessingThread?.join(500) } catch (e: InterruptedException) { Log.w(TAG, "BoostedMicTest: Join interrupted", e); Thread.currentThread().interrupt() } }
+        Log.d(TAG, "AudioLoopService: Stopping audio processing...")
+        if (_isRunning.value == true) { 
+             _isRunning.postValue(false)
+        }
+        isCapturingAppAudio = false; isCapturingMicAudio = false;
+        
+        audioProcessingThread?.interrupt()
+        try { audioProcessingThread?.join(500) }
+        catch (e: InterruptedException) { Log.w(TAG, "AudioLoopService: Join interrupted", e); Thread.currentThread().interrupt() }
         audioProcessingThread = null
+
         appAudioRecord?.apply { if (recordingState == AudioRecord.RECORDSTATE_RECORDING) stop(); release() }; appAudioRecord = null
         micAudioRecord?.apply { if (recordingState == AudioRecord.RECORDSTATE_RECORDING) stop(); release() }; micAudioRecord = null
-        audioTrack?.apply { if (playState != AudioTrack.PLAYSTATE_STOPPED) { pause(); flush(); stop(); }; release() }; audioTrack = null
-        Log.d(TAG, "BoostedMicTest: All audio resources released.")
-        _isRunning.postValue(false)
+        audioTrack?.apply { if (playState != AudioTrack.PLAYSTATE_STOPPED) { try { pause() } catch (e: IllegalStateException) {} ; flush(); stop() }; release() }; audioTrack = null
+        Log.d(TAG, "AudioLoopService: All audio resources released.")
     }
 
-    private fun startForegroundNotification() {
-        val statusText = if (_isRunning.value == true) "Looping Audio (Boosted Mic)" else "Ready (Boosted Mic Test)"
-        val channelId = "AudioLoopServiceChannel"; if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { val channel = NotificationChannel(channelId, "Audio Loop Service", NotificationManager.IMPORTANCE_LOW); notificationManager = getSystemService(NotificationManager::class.java); notificationManager?.createNotificationChannel(channel) }; val notification: Notification = NotificationCompat.Builder(this, channelId).setContentTitle("AudioLoop (Boosted Mic Test)").setContentText(statusText).setSmallIcon(R.mipmap.ic_launcher).setOngoing(true).build(); try { startForeground(SERVICE_NOTIFICATION_ID, notification) } catch (e: Exception) { Log.e(TAG, "BoostedMicTest: Error starting fg", e) }
+    private fun startForegroundNotification() { /* ... same as before ... */
+         val statusText = if (_isRunning.value == true) "Looping Audio" else "Ready"
+        val channelId = "AudioLoopServiceChannel"; if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { val channel = NotificationChannel(channelId, "Audio Loop Service", NotificationManager.IMPORTANCE_LOW); notificationManager = getSystemService(NotificationManager::class.java); notificationManager?.createNotificationChannel(channel) }; val notification: Notification = NotificationCompat.Builder(this, channelId).setContentTitle("AudioLoop").setContentText(statusText).setSmallIcon(R.mipmap.ic_launcher).setOngoing(true).build(); try { startForeground(SERVICE_NOTIFICATION_ID, notification) } catch (e: Exception) { Log.e(TAG, "AudioLoopService: Error starting fg", e) }
     }
 
-    private fun clearProjectionAndAudioInstance() { 
-        Log.d(TAG, "BoostedMicTest: Clearing MediaProjection and stopping audio.")
-        stopAudioProcessing()
-        currentMediaProjection?.unregisterCallback(mediaProjectionCallback)
-        currentMediaProjection?.stop()
-        currentMediaProjection = null
-        startForegroundNotification() // Update notification to "Ready"
-    }
-
-    private var actionBeingProcessed : String? = null
-
+    private fun clearProjectionAndAudioInstance() { Log.d(TAG, "AudioLoopService: Clearing MediaProjection and stopping audio."); stopAudioProcessing(); currentMediaProjection?.unregisterCallback(mediaProjectionCallback); currentMediaProjection?.stop(); currentMediaProjection = null; startForegroundNotification() }
+    
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        actionBeingProcessed = intent?.action
-        Log.d(TAG, "BoostedMicTest: onStartCommand, action: $actionBeingProcessed")
-        when (actionBeingProcessed) {
-            ACTION_START_SERVICE -> { 
-                Log.d(TAG, "BoostedMicTest: ACTION_START_SERVICE - Service is preparing.")
-                // This action now primarily ensures the service is in a started state with notification.
-                // Actual audio processing start is triggered by ACTION_PROCESS_AUDIO_START
+        val currentAction = intent?.action // Use a local val for the action
+        Log.d(TAG, "AudioLoopService: onStartCommand, action: $currentAction, current _isRunning: ${_isRunning.value}")
+        when (currentAction) {
+            ACTION_START_SERVICE -> { startForegroundNotification() }
+            ACTION_PROCESS_AUDIO_START -> {
+                if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+                    startAudioProcessing()
+                } else { Log.e(TAG, "AudioLoopService: RECORD_AUDIO perm not granted for START."); _isRunning.postValue(false) }
                 startForegroundNotification() 
             }
-            ACTION_PROCESS_AUDIO_START -> {
-                Log.d(TAG, "BoostedMicTest: ACTION_PROCESS_AUDIO_START")
-                if (currentMediaProjection != null) {
-                    if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-                        startAudioProcessing()
-                    } else {
-                        Log.e(TAG, "BoostedMicTest: RECORD_AUDIO permission not granted for PROCESS_AUDIO_START.")
-                        _isRunning.postValue(false) // Ensure UI reflects this state
-                    }
-                } else {
-                    Log.w(TAG, "BoostedMicTest: MediaProjection not available. Cannot start audio processing.")
-                     _isRunning.postValue(false) // Ensure UI reflects this state
-                }
-                startForegroundNotification() // Update notification based on new state
-            }
-            ACTION_PROCESS_AUDIO_STOP -> {
-                Log.d(TAG, "BoostedMicTest: ACTION_PROCESS_AUDIO_STOP")
-                stopAudioProcessing()
-                startForegroundNotification() // Update notification based on new state
-            }
-            ACTION_STOP_SERVICE -> { 
-                Log.d(TAG, "BoostedMicTest: ACTION_STOP_SERVICE")
-                clearProjectionAndAudioInstance()
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf() 
-            }
+            ACTION_PROCESS_AUDIO_STOP -> { stopAudioProcessing(); startForegroundNotification() }
+            ACTION_STOP_SERVICE -> { clearProjectionAndAudioInstance(); stopForeground(STOP_FOREGROUND_REMOVE); stopSelf() }
             ACTION_SETUP_PROJECTION -> {
-                Log.d(TAG, "BoostedMicTest: ACTION_SETUP_PROJECTION")
-                // Stop any previous processing before setting up new projection
                 stopAudioProcessing() 
-                if (currentMediaProjection != null) { 
-                    currentMediaProjection?.unregisterCallback(mediaProjectionCallback)
-                    currentMediaProjection?.stop()
-                    currentMediaProjection = null 
-                }
-                val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
-                val data: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) intent.getParcelableExtra(EXTRA_DATA_INTENT, Intent::class.java) else @Suppress("DEPRECATION") intent.getParcelableExtra(EXTRA_DATA_INTENT)
+                if (currentMediaProjection != null) { currentMediaProjection?.unregisterCallback(mediaProjectionCallback); currentMediaProjection?.stop(); currentMediaProjection = null }
                 
+                val resultCode = intent?.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED) ?: Activity.RESULT_CANCELED
+                val data: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent?.getParcelableExtra(EXTRA_DATA_INTENT, Intent::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent?.getParcelableExtra(EXTRA_DATA_INTENT)
+                }
+
                 if (resultCode == Activity.RESULT_OK && data != null) {
-                    try {
+                    try { 
                         val projection = mediaProjectionManager.getMediaProjection(resultCode, data)
-                        if (projection != null) {
+                        if (projection != null) { 
                             currentMediaProjection = projection
                             currentMediaProjection?.registerCallback(mediaProjectionCallback, null)
-                            Log.d(TAG, "BoostedMicTest: MediaProjection obtained and callback registered.")
-                            // Do not start audio processing here. Wait for ACTION_PROCESS_AUDIO_START
-                            _isRunning.postValue(false) // Projection is ready, but not processing yet
-                        } else {
-                             Log.e(TAG, "BoostedMicTest: getMediaProjection returned null.")
-                             _isRunning.postValue(false)
+                            Log.d(TAG, "AudioLoopService: MediaProjection obtained.")
+                            _isRunning.postValue(false) // Update state as projection is set up but not yet looping
+                        } else { 
+                            Log.e(TAG, "AudioLoopService: getMediaProjection returned null.")
+                            _isRunning.postValue(false) 
                         }
                     } catch (e: Exception) { 
-                        Log.e(TAG, "BoostedMicTest: Exception in ACTION_SETUP_PROJECTION", e)
-                        _isRunning.postValue(false)
+                        Log.e(TAG, "AudioLoopService: Ex in ACTION_SETUP_PROJECTION", e)
+                        _isRunning.postValue(false) 
                     }
-                } else {
-                    Log.w(TAG, "BoostedMicTest: ACTION_SETUP_PROJECTION failed. ResultCode: $resultCode")
-                    _isRunning.postValue(false)
+                } else { 
+                    Log.w(TAG, "AudioLoopService: ACTION_SETUP_PROJECTION failed. ResultCode: $resultCode, Data is null: ${data==null}")
+                    _isRunning.postValue(false) 
                 }
-                startForegroundNotification() // Update notification (e.g., to "Ready" or "Projection Set")
+                startForegroundNotification() 
+            }
+            ACTION_REQUEST_STATE -> {
+                 Log.d(TAG, "AudioLoopService: ACTION_REQUEST_STATE received. Current _isRunning: ${_isRunning.value}. Broadcasting to FloatingControlsService.")
+                 val updateIntent = Intent(FloatingControlsService.ACTION_UPDATE_ICON)
+                 updateIntent.putExtra(FloatingControlsService.EXTRA_IS_RUNNING, _isRunning.value ?: false)
+                 sendBroadcast(updateIntent)
             }
         }
-        actionBeingProcessed = null // Reset after handling
         return START_NOT_STICKY
     }
 
-    private val mediaProjectionCallback = object : MediaProjection.Callback() { 
-        override fun onStop() { 
-            super.onStop()
-            Log.w(TAG, "BoostedMicTest: Projection stopped externally.")
-            // If projection stops, we must stop audio processing and update state.
-            clearProjectionAndAudioInstance() 
-            _isRunning.postValue(false)
-        }
-    }
+    private val mediaProjectionCallback = object : MediaProjection.Callback() { override fun onStop() { super.onStop(); Log.w(TAG, "AudioLoopService: Projection stopped externally."); clearProjectionAndAudioInstance() } }
+    
     override fun onDestroy() { 
         super.onDestroy()
-        Log.d(TAG, "BoostedMicTest: Service onDestroy")
+        Log.d(TAG, "AudioLoopService: onDestroy. Removing LiveData observer.")
+        _isRunning.removeObserver(runningStateObserver) 
         abandonAudioFocus()
         clearProjectionAndAudioInstance()
-        // _isRunning.postValue(false) // Already handled by clearProjectionAndAudioInstance
     }
     override fun onBind(intent: Intent?): IBinder? = null
 
     companion object {
-        private const val TAG = "AudioLoopService"
+        private const val TAG = "AudioLoopApp" // Unified TAG
         private const val SERVICE_NOTIFICATION_ID = 12345
+        private const val MIC_GAIN_FACTOR = 8
         const val ACTION_START_SERVICE = "com.audioloop.audioloop.ACTION_START_SERVICE"
         const val ACTION_STOP_SERVICE = "com.audioloop.audioloop.ACTION_STOP_SERVICE"
         const val ACTION_SETUP_PROJECTION = "com.audioloop.audioloop.ACTION_SETUP_PROJECTION"
         const val ACTION_PROCESS_AUDIO_START = "com.audioloop.audioloop.ACTION_PROCESS_AUDIO_START"
         const val ACTION_PROCESS_AUDIO_STOP = "com.audioloop.audioloop.ACTION_PROCESS_AUDIO_STOP"
+        const val ACTION_REQUEST_STATE = "com.audioloop.audioloop.ACTION_REQUEST_STATE"
         const val EXTRA_RESULT_CODE = "com.audioloop.audioloop.EXTRA_RESULT_CODE"
         const val EXTRA_DATA_INTENT = "com.audioloop.audioloop.EXTRA_DATA_INTENT"
         var currentMediaProjection: MediaProjection? = null; private set

--- a/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
@@ -1,128 +1,228 @@
 package com.audioloop.audioloop
 
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.Configuration
 import android.graphics.PixelFormat
 import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
+import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.Toast
-// import com.audioloop.audioloop.R // Already implicitly available by package
+import androidx.core.app.NotificationCompat
 
 class FloatingControlsService : Service() {
 
     private lateinit var windowManager: WindowManager
-    private var floatingGadget: View? = null
-    private lateinit var params: WindowManager.LayoutParams
+    private var floatingGadget: ViewGroup? = null
     private var iconView: ImageView? = null
+    private var closeButton: ImageButton? = null
+    private var isExpanded: Boolean = false
 
-    private var initialX: Int = 0
-    private var initialY: Int = 0
-    private var initialTouchX: Float = 0.0f
-    private var initialTouchY: Float = 0.0f
+    private lateinit var params: WindowManager.LayoutParams
+    private var lastAction = 0
+    private var initialX = 0
+    private var initialY = 0
+    private var initialTouchX = 0f
+    private var initialTouchY = 0f
 
-    // Observe AudioLoopService.isRunning to update UI
-    private val audioLoopServiceRunningObserver = androidx.lifecycle.Observer<Boolean> {
-        isServiceRunning -> updateIcon(isServiceRunning)
+    private var isServiceRunning = false
+
+    companion object {
+        private const val TAG = "AudioLoopApp"
+        private const val NOTIFICATION_ID = 3
+        private const val CHANNEL_ID = "FloatingControlsChannel"
+        const val ACTION_UPDATE_ICON = "com.audioloop.audioloop.UPDATE_ICON"
+        const val EXTRA_IS_RUNNING = "IS_RUNNING"
+    }
+
+    private val stateUpdateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == ACTION_UPDATE_ICON) {
+                val previousState = isServiceRunning
+                val newState = intent.getBooleanExtra(EXTRA_IS_RUNNING, false)
+                isServiceRunning = newState
+                Log.d(TAG, "FloatingControlsService.stateUpdateReceiver: ACTION_UPDATE_ICON received. Prev isServiceRunning: $previousState, New isServiceRunning: $isServiceRunning")
+                updateIcon()
+            }
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? {
+        Log.d(TAG, "FloatingControlsService: onBind called")
         return null
     }
 
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onCreate() {
         super.onCreate()
+        Log.d(TAG, "FloatingControlsService: onCreate called. Initial isServiceRunning: $isServiceRunning")
+
+        val intentFilter = IntentFilter(ACTION_UPDATE_ICON)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(stateUpdateReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(stateUpdateReceiver, intentFilter)
+        }
+        Log.d(TAG, "FloatingControlsService: stateUpdateReceiver registered.")
+
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
-            // This service should ideally not be started if permission is not granted.
-            // MainActivity should handle this check before starting the service.
-            Toast.makeText(this, "Overlay permission not granted", Toast.LENGTH_LONG).show()
+            Log.e(TAG, "FloatingControlsService: Overlay permission not granted. Stopping service.")
+            Toast.makeText(this, "Overlay permission not granted.", Toast.LENGTH_LONG).show()
             stopSelf()
             return
         }
 
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
-
         val inflater = getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        floatingGadget = inflater.inflate(R.layout.floating_gadget, null)
-        iconView = floatingGadget?.findViewById<ImageView>(R.id.floating_widget_icon)
-
-        val layoutFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
-        } else {
-            @Suppress("DEPRECATION")
-            WindowManager.LayoutParams.TYPE_PHONE
-        }
-
-        params = WindowManager.LayoutParams(
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            layoutFlag,
-            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
-            PixelFormat.TRANSLUCENT
-        )
-
-        params.gravity = Gravity.TOP or Gravity.START
-        params.x = 0
-        params.y = 100 // Initial position
 
         try {
-            windowManager.addView(floatingGadget, params)
-        } catch (e: Exception) {
-            // Handle cases where window manager might fail (e.g. after screen rotation if not handled)
-            stopSelf()
-            return
-        }
+            val inflatedView = inflater.inflate(R.layout.floating_gadget, null)
+            if (inflatedView == null) {
+                Log.e(TAG, "FloatingControlsService: Critical - inflater.inflate returned null for R.layout.floating_gadget")
+                Toast.makeText(this, "Error: Inflation returned null.", Toast.LENGTH_LONG).show()
+                stopSelf(); return
+            }
 
-        setupTouchListener()
-        setupClickListener()
+            iconView = inflatedView.findViewById<ImageView>(R.id.floating_widget_icon)
+            closeButton = inflatedView.findViewById<ImageButton>(R.id.floating_widget_close_button)
 
-        // Observe the LiveData from AudioLoopService
-        // We need a way to get the main Looper for LiveData observation if this service is not on main thread
-        // However, Service lifecycle methods are called on the main thread by default.
-        AudioLoopService.isRunning.observeForever(audioLoopServiceRunningObserver)
-        updateIcon(AudioLoopService.isRunning.value ?: false) // Initial icon state
-    }
+            if (iconView == null) {
+                Log.e(TAG, "FloatingControlsService: Critical - iconView not found.")
+                Toast.makeText(this, "Error: iconView not found.", Toast.LENGTH_LONG).show()
+                stopSelf(); return
+            }
+            if (closeButton == null) {
+                Log.e(TAG, "FloatingControlsService: Critical - closeButton not found.")
+                Toast.makeText(this, "Error: closeButton not found.", Toast.LENGTH_LONG).show()
+                stopSelf(); return
+            }
 
-    private fun updateIcon(isRunning: Boolean) {
-        if (isRunning) {
-            iconView?.setImageResource(R.drawable.ic_stop) // Replace with your actual stop icon
-            iconView?.alpha = 1.0f // Full opacity when running
-        } else {
-            iconView?.setImageResource(R.drawable.ic_play) // Replace with your actual play icon
-            iconView?.alpha = 0.7f // Slightly dimmed when not running, to show it'''s active but pausable
-        }
-    }
-
-    private fun setupClickListener() {
-        iconView?.setOnClickListener {
-            val currentServiceState = AudioLoopService.isRunning.value ?: false
-            if (currentServiceState) {
-                sendActionToAudioLoopService(AudioLoopService.ACTION_PROCESS_AUDIO_STOP)
+            if (inflatedView is ViewGroup) {
+                floatingGadget = inflatedView
             } else {
-                if (AudioLoopService.isProjectionSetup()) {
-                    sendActionToAudioLoopService(AudioLoopService.ACTION_PROCESS_AUDIO_START)
+                Log.e(TAG, "FloatingControlsService: Critical - Inflated view is not a ViewGroup.")
+                Toast.makeText(this, "Error: Inflated layout is not ViewGroup.", Toast.LENGTH_LONG).show()
+                stopSelf(); return
+            }
+
+            // Let the XML define the initial visual state
+            // floatingGadget?.setBackgroundColor(Color.parseColor("#80FF0000")) // Removed debug background
+            // iconView?.setImageResource(android.R.drawable.sym_def_app_icon) // Removed debug icon
+
+            closeButton?.visibility = View.GONE
+
+            val layoutFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+            } else {
+                @Suppress("DEPRECATION")
+                WindowManager.LayoutParams.TYPE_PHONE
+            }
+
+            params = WindowManager.LayoutParams(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                layoutFlag,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                PixelFormat.TRANSLUCENT
+            ).apply {
+                gravity = Gravity.TOP or Gravity.START
+                x = 0
+                y = 100
+            }
+
+            windowManager.addView(floatingGadget, params)
+            Log.d(TAG, "FloatingControlsService: Floating gadget added to WindowManager.")
+
+            setupTouchListener()
+            setupIconPlayStopClickListener()
+            setupIconLongClickListener()
+            setupCloseButtonClickListener()
+
+            startForeground(NOTIFICATION_ID, createNotification())
+            Log.d(TAG, "FloatingControlsService: Service started in foreground.")
+
+            Log.d(TAG, "FloatingControlsService: Sending ACTION_REQUEST_STATE to AudioLoopService.")
+            sendBroadcast(Intent(AudioLoopService.ACTION_REQUEST_STATE))
+
+        } catch (e: Exception) {
+            Log.e(TAG, "FloatingControlsService: Error during floating widget setup: ${e.message}", e)
+            Toast.makeText(this, "Setup Error: ${e.message?.take(50)}", Toast.LENGTH_LONG).show()
+            stopSelf()
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action
+        Log.d(TAG, "FloatingControlsService: onStartCommand received action: $action")
+        return START_STICKY
+    }
+
+    private fun updateIcon() {
+        Log.d(TAG, "FloatingControlsService: updateIcon() called. isServiceRunning: $isServiceRunning")
+        if (isServiceRunning) {
+            iconView?.setImageResource(R.drawable.ic_stop)
+        } else {
+            iconView?.setImageResource(R.drawable.ic_play)
+        }
+        iconView?.invalidate()
+        floatingGadget?.invalidate()
+        Log.d(TAG, "FloatingControlsService: iconView updated and invalidated.")
+    }
+
+    private fun setupIconPlayStopClickListener() {
+        iconView?.setOnClickListener {
+            Log.d(TAG, "FloatingControlsService: iconView clicked. Current isServiceRunning: $isServiceRunning, isExpanded: $isExpanded")
+            if (!isExpanded) {
+                val serviceIntent = Intent(this, AudioLoopService::class.java)
+                if (isServiceRunning) {
+                    serviceIntent.action = AudioLoopService.ACTION_PROCESS_AUDIO_STOP
                 } else {
-                    Toast.makeText(this, "Screen capture not set up. Please set up from the main app.", Toast.LENGTH_LONG).show()
-                    // Optionally, could try to bring MainActivity to front or send a signal
+                    serviceIntent.action = AudioLoopService.ACTION_PROCESS_AUDIO_START
                 }
+                Log.d(TAG, "FloatingControlsService: Sending action to AudioLoopService: ${serviceIntent.action}")
+                startService(serviceIntent)
+            } else {
+                Log.d(TAG, "FloatingControlsService: iconView clicked, but widget is expanded. No play/stop action.")
             }
         }
     }
 
-    private fun sendActionToAudioLoopService(action: String) {
-        val serviceIntent = Intent(this, AudioLoopService::class.java)
-        serviceIntent.action = action
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(serviceIntent) // Ensure AudioLoopService also calls startForeground for its notification
-        } else {
-            startService(serviceIntent)
+    private fun toggleExpandState() {
+        isExpanded = !isExpanded
+        closeButton?.visibility = if (isExpanded) View.VISIBLE else View.GONE
+        Log.d(TAG, "FloatingControlsService: Toggled expand state. isExpanded: $isExpanded, closeButton visibility: ${closeButton?.visibility}")
+    }
+
+    private fun setupIconLongClickListener() {
+        iconView?.setOnLongClickListener {
+            Log.d(TAG, "FloatingControlsService: iconView long-clicked.")
+            toggleExpandState()
+            true
+        }
+    }
+
+    private fun setupCloseButtonClickListener() {
+        closeButton?.setOnClickListener {
+            Log.d(TAG, "FloatingControlsService: closeButton clicked.")
+            stopSelf()
         }
     }
 
@@ -130,36 +230,62 @@ class FloatingControlsService : Service() {
         floatingGadget?.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialX = params.x
-                    initialY = params.y
-                    initialTouchX = event.rawX
-                    initialTouchY = event.rawY
-                    true
+                    lastAction = MotionEvent.ACTION_DOWN; initialX = params.x; initialY = params.y
+                    initialTouchX = event.rawX; initialTouchY = event.rawY; true
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    params.x = initialX + (event.rawX - initialTouchX).toInt()
-                    params.y = initialY + (event.rawY - initialTouchY).toInt()
-                    try {
-                        windowManager.updateViewLayout(floatingGadget, params)
-                    } catch (e: Exception) {
-                        // Could happen if service is stopping/view removed
-                    }
-                    true
+                    if (lastAction == MotionEvent.ACTION_DOWN || lastAction == MotionEvent.ACTION_MOVE) {
+                        if (!isExpanded) {
+                            params.x = initialX + (event.rawX - initialTouchX).toInt()
+                            params.y = initialY + (event.rawY - initialTouchY).toInt()
+                            try {
+                                windowManager.updateViewLayout(floatingGadget, params)
+                            } catch (e: Exception) {
+                                Log.e(TAG, "FloatingControlsService: Error updating layout", e)
+                            }
+                        }
+                        lastAction = MotionEvent.ACTION_MOVE
+                    }; true
+                }
+                MotionEvent.ACTION_UP -> {
+                    lastAction = MotionEvent.ACTION_UP; event.action == MotionEvent.ACTION_MOVE
                 }
                 else -> false
             }
         }
     }
 
+    private fun createNotification(): Notification {
+        createNotificationChannel()
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        return NotificationCompat.Builder(this, CHANNEL_ID).setContentTitle("Floating Controls Active").setContentText("Controls are visible.").setSmallIcon(R.mipmap.ic_launcher_round).setContentIntent(pendingIntent).setPriority(NotificationCompat.PRIORITY_LOW).build()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val serviceChannel = NotificationChannel(CHANNEL_ID, "Floating Controls Channel", NotificationManager.IMPORTANCE_LOW)
+            getSystemService(NotificationManager::class.java)?.createNotificationChannel(serviceChannel)
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
-        floatingGadget?.let {
+        unregisterReceiver(stateUpdateReceiver)
+        Log.d(TAG, "FloatingControlsService: stateUpdateReceiver unregistered.")
+        Log.d(TAG, "FloatingControlsService: onDestroy called")
+        if (floatingGadget?.windowToken != null) {
             try {
-                windowManager.removeView(it)
+                windowManager.removeView(floatingGadget)
             } catch (e: Exception) {
-                // Handle if view already removed or window manager service not available
+                Log.e(TAG, "FloatingControlsService: Error removing view: ${e.message}", e)
             }
         }
-        AudioLoopService.isRunning.removeObserver(audioLoopServiceRunningObserver)
+        floatingGadget = null; iconView = null; closeButton = null
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        Log.d(TAG, "FloatingControlsService: onConfigurationChanged: ${newConfig.orientation}")
     }
 }

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play.xml
+++ b/app/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,6h12v12H6z" />
+</vector>

--- a/app/src/main/res/layout/floating_gadget.xml
+++ b/app/src/main/res/layout/floating_gadget.xml
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/floating_widget_container"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:padding="8dp">
 
     <ImageView
         android:id="@+id/floating_widget_icon"
         android:layout_width="56dp"
         android:layout_height="56dp"
         android:src="@mipmap/ic_launcher_round"
-        android:contentDescription="AudioLoop Control" />
+        android:contentDescription="AudioLoop Control Icon" />
 
-</FrameLayout>
+    <ImageButton
+        android:id="@+id/floating_widget_close_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_close"
+        android:contentDescription="Close Floating Controls"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,19 @@
-org.gradle.daemon=true
-org.gradle.parallel=true
-org.gradle.caching=true
-
-# AndroidX Properties
-android.useAndroidX=true
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# org.gradle.parallel=true
+#Thu Sep 18 22:29:20 CEST 2025
 android.enableJetifier=true
-
-# Kotlin KAPT options (can be fine-tuned)
-# kapt.useBuildCache=true
-# kapt.incremental.apt=true
-
-# JVM arguments for Gradle - REMOVED the extensive --add-opens here
-# If you ensure Gradle uses JDK 17, these might not be needed globally.
-# The kapt.javacOptions in build.gradle.kts (:app) are more specific.
-# org.gradle.jvmargs=-Xmx2048m -Dkotlin.daemon.jvm.options="-Xmx1536m"
+android.useAndroidX=true
+org.gradle.caching=true
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.parallel=true


### PR DESCRIPTION
Add broadcast receiver to update floating control icon when the main
AudioLoopService state changes. Register the receiver safely for newer
SDKs and log lifecycle events for easier debugging.

Improve floating widget behavior and UX:
- Convert root view to ViewGroup to manage close button and expanded state.
- Track touch motion (initial positions, lastAction) to support dragging
  and distinguish clicks from moves.
- Add ImageButton for close action and wire up expanded/collapsed state.

Add foreground notification support scaffolding:
- Define notification channel and constants (CHANNEL_ID, NOTIFICATION_ID)
  to allow promoting the service to foreground if needed.

Improve permission and lifecycle handling:
- Check and abort when overlay permission is missing, with a log entry.
- Log register/unregister of the receiver and key lifecycle callbacks.

Misc cleanup:
- Import androidX NotificationCompat and other required classes.
- Remove unused observer code and replace it with the broadcast-based
  update mechanism.