### PR TITLE
feat(ui): refine visuals and add app audio gain intents

### DIFF
--- a/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
@@ -66,6 +66,8 @@ class FloatingControlsService : Service() {
         const val EXTRA_IS_MIC_MUTED = "EXTRA_IS_MIC_MUTED"
         const val ACTION_UPDATE_MIC_GAIN = "ACTION_UPDATE_MIC_GAIN"
         const val EXTRA_MIC_GAIN_LEVEL = "EXTRA_MIC_GAIN_LEVEL"
+        const val ACTION_UPDATE_APP_AUDIO_GAIN = "ACTION_UPDATE_APP_AUDIO_GAIN"
+        const val EXTRA_APP_AUDIO_GAIN_LEVEL = "EXTRA_APP_AUDIO_GAIN_LEVEL"
     }
 
     private val stateUpdateReceiver = object : BroadcastReceiver() {

--- a/app/src/main/res/drawable/bg_glowing_gradient_circle.xml
+++ b/app/src/main/res/drawable/bg_glowing_gradient_circle.xml
@@ -6,6 +6,5 @@
         android:gradientRadius="80%p"
         android:centerColor="@color/glowing_blue_start"
         android:endColor="@color/glowing_blue_end"
-        android:startColor="@color/purple_accent" /> <!-- Added purple for a richer gradient -->
-    <!-- A slight inner shadow or glow effect could be added here if needed, but might require layer-list or different approach -->
+        android:startColor="@color/purple_accent" />
 </shape>

--- a/app/src/main/res/drawable/ic_waveform_orange_blue.xml
+++ b/app/src/main/res/drawable/ic_waveform_orange_blue.xml
@@ -4,26 +4,7 @@
     android:height="20dp"
     android:viewportWidth="150"
     android:viewportHeight="20">
-    <!-- This is a static representation. A real waveform would be dynamically drawn. -->
-    <!-- Example using multiple rectangles to simulate a waveform -->
-    <rect width="4" height="10" x="5" y="5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="15" x="12" y="2.5" fillColor="@color/waveform_blue" />
-    <rect width="4" height="12" x="19" y="4" fillColor="@color/waveform_orange" />
-    <rect width="4" height="18" x="26" y="1" fillColor="@color/waveform_blue" />
-    <rect width="4" height="16" x="33" y="2" fillColor="@color/waveform_orange" />
-    <rect width="4" height="14" x="40" y="3" fillColor="@color/waveform_blue" />
-    <rect width="4" height="11" x="47" y="4.5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="17" x="54" y="1.5" fillColor="@color/waveform_blue" />
-    <rect width="4" height="13" x="61" y="3.5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="19" x="68" y="0.5" fillColor="@color/waveform_blue" />
-    <rect width="4" height="15" x="75" y="2.5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="12" x="82" y="4" fillColor="@color/waveform_blue" />
-    <rect width="4" height="10" x="89" y="5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="16" x="96" y="2" fillColor="@color/waveform_blue" />
-    <rect width="4" height="14" x="103" y="3" fillColor="@color/waveform_orange" />
-    <rect width="4" height="11" x="110" y="4.5" fillColor="@color/waveform_blue" />
-    <rect width="4" height="18" x="117" y="1" fillColor="@color/waveform_orange" />
-    <rect width="4" height="13" x="124" y="3.5" fillColor="@color/waveform_blue" />
-    <rect width="4" height="17" x="131" y="1.5" fillColor="@color/waveform_orange" />
-    <rect width="4" height="14" x="138" y="3" fillColor="@color/waveform_blue" />
+    <path
+        android:fillColor="@color/waveform_orange"
+        android:pathData="M0,10 C15,5 30,15 45,10 S75,5 90,10 120,15 135,10 150,5 150,5 L150,15 C135,20 120,10 105,15 S75,20 60,15 30,10 15,15 0,20 0,20 Z" />
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="white">#FFFFFF</color>
-    <color name="rose_gold_accent">#B76E79</color> <!-- Example Rose Gold color -->
-    <color name="white_translucent">#B3FFFFFF</color> <!-- White with alpha -->
-    <color name="white_translucent_high">#E6FFFFFF</color> <!-- White with higher alpha -->
-    <color name="brushed_metal_dark">#2A2A2A</color> <!-- Dark gray for brushed metal -->
-    <color name="glowing_blue_start">#00BFFF</color> <!-- Deep Sky Blue -->
-    <color name="glowing_blue_end">#87CEEB</color> <!-- Sky Blue -->
-    <color name="waveform_orange">#FFA500</color> <!-- Orange -->
-    <color name="waveform_blue">#1E90FF</color> <!-- Dodger Blue -->
-    <color name="purple_accent">#9370DB</color> <!-- Medium Purple -->
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+    <color name="rose_gold_accent">#B76E79</color>
+    <color name="white_translucent">#80FFFFFF</color>
+    <color name="white_translucent_high">#CCFFFFFF</color>
+    <color name="dark_charcoal_gray">#333333</color>
+    <color name="glowing_neon_blue">#00F0FF</color>
+    <color name="glowing_neon_cyan">#00FFFF</color>
+    <color name="glowing_orange">#FFA500</color>
+    <color name="glowing_blue">#0000FF</color>
+    <color name="waveform_orange">#FFA500</color>
+    <color name="waveform_blue">#00BFFF</color>
+    <color name="glowing_blue_start">#00F0FF</color>
+    <color name="glowing_blue_end">#00A5FF</color>
+    <color name="purple_accent">#BB86FC</color>
+    <color name="brushed_metal_dark">#2C2C2C</color>
 </resources>


### PR DESCRIPTION
- clean up glowing gradient drawable: remove leftover comment and
  tidy attributes in bg_glowing_gradient_circle.xml to keep the shape
  definition concise.
- replace static multi-rect waveform vector with a single smooth
  path in ic_waveform_orange_blue.xml to simplify the drawable and
  produce a smoother, more scalable waveform graphic.
- expand and normalize color palette in values/colors.xml:
  add Material-like purple/teal shades, clearer black/white and
  translucency values, introduce named neon/glowing colors and
  harmonize waveform colors for consistent theming.
- add new intent/action constants to FloatingControlsService.kt:
  ACTION_UPDATE_APP_AUDIO_GAIN and EXTRA_APP_AUDIO_GAIN_LEVEL to
  support broadcasting app audio gain updates alongside existing
  mic controls.

Reason: Visual cleanup and palette consolidation improve maintain-
ability and theming consistency; replacing the rect-based waveform
with a path reduces XML noise and scales better. Adding app audio
gain intents prepares the service to accept and propagate audio
gain changes for app playback.