### PR TITLE
fix: correct logging and set receiver export flags for security

### DIFF
--- a/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/AudioLoopService.kt
@@ -97,18 +97,18 @@ class AudioLoopService : Service() {
                 FloatingControlsService.ACTION_TOGGLE_MIC_MUTE -> {
                     val isMuted = intent.getBooleanExtra(FloatingControlsService.EXTRA_IS_MIC_MUTED, false)
                     isMicMuted = isMuted
-                    Log.d(TAG, "AudioLoopService: Mic mute toggled to $isMicMuted")
+                    Log.d(TAG, "AudioLoopService: Mic mute toggled to $isMuted")
                     // The mute logic will be applied in the audio processing thread
                 }
                 FloatingControlsService.ACTION_UPDATE_MIC_GAIN -> {
                     val gain = intent.getIntExtra(FloatingControlsService.EXTRA_MIC_GAIN_LEVEL, 0)
                     micGain = gain
-                    Log.d(TAG, "AudioLoopService: Mic gain updated to $micGain")
+                    Log.d(TAG, "AudioLoopService: Mic gain updated to $gain")
                 }
                 FloatingControlsService.ACTION_UPDATE_APP_AUDIO_GAIN -> {
                     val gain = intent.getIntExtra(FloatingControlsService.EXTRA_APP_AUDIO_GAIN_LEVEL, 0)
                     appAudioGain = gain
-                    Log.d(TAG, "AudioLoopService: App audio gain updated to $appAudioGain")
+                    Log.d(TAG, "AudioLoopService: App audio gain updated to $gain")
                 }
             }
         }
@@ -132,7 +132,11 @@ class AudioLoopService : Service() {
             addAction(FloatingControlsService.ACTION_UPDATE_MIC_GAIN)
             addAction(FloatingControlsService.ACTION_UPDATE_APP_AUDIO_GAIN)
         }
-        registerReceiver(controlReceiver, filter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(controlReceiver, filter, RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(controlReceiver, filter)
+        }
     }
 
     private fun setupAudioFocusListener() {

--- a/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
+++ b/app/src/main/java/com/audioloop/audioloop/FloatingControlsService.kt
@@ -176,7 +176,11 @@ class FloatingControlsService : Service() {
             addAction(ACTION_UPDATE_STATE)
             addAction(ACTION_TOGGLE_MIC_MUTE)
         }
-        registerReceiver(stateUpdateReceiver, filter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            registerReceiver(stateUpdateReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(stateUpdateReceiver, filter)
+        }
 
         setupTouchListener()
         updateUIForServiceState()


### PR DESCRIPTION
Update AudioLoopService and FloatingControlsService to (1) fix
debug logs to print the actual local values passed from intents and
(2) register broadcast receivers with the non-exported flag on newer
Android versions.

- Replace logs that referenced mutated fields (isMicMuted, micGain,
  appAudioGain) with the immediate values (isMuted, gain) to avoid
  misleading output and make logs reflect the intent payload.
- Use RECEIVER_NOT_EXPORTED / Context.RECEIVER_NOT_EXPORTED when
  registering receivers on recent SDKs (TIRAMISU / S) to prevent
  unintended external broadcasts, falling back to the previous
  registerReceiver overload on older SDKs.

These changes improve diagnostic accuracy and harden receiver
registration against external injection on modern Android releases.