### PR TITLE
style(colors): adjust theme palette to warmer tones

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <color name="purple_200">#FFB6C1</color> <!-- LightPink - warmer purple/pink -->
+    <color name="purple_500">#DC143C</color> <!-- Crimson - warm red -->
+    <color name="purple_700">#8B0000</color> <!-- DarkRed - deep warm red -->
+    <color name="teal_200">#98FB98</color> <!-- PaleGreen - warmer light green -->
+    <color name="teal_700">#228B22</color> <!-- ForestGreen - warmer deep green -->
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="rose_gold_accent">#B76E79</color>


### PR DESCRIPTION
Update app color resources to a warmer, more saturated to
improve warmth and brand. Replace original purple
and teal shades with red/pink and green:

- purple_: LightPinkFFB6C1) for a warmer light accent.
- purple_500: Crimson (#DC143C) for a warm mid-tone primary.
- purple_700: DarkRed (#8B0000) for a deep warm primary.
- teal_200: PaleGreen (#98FB98) for a softer warm light green.
- teal_700: ForestGreen (#228B22) for a richer deep green.

Keep black, white, and rose_gold_accent unchanged. This improves
contrast and creates a cohesive, warmer color direction across the app.