### PR TITLE
fix(ci): use proper GitHub Actions expression for condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Decode Keystore
         id: decode_keystore
-        if: secrets.SIGNING_KEY_STORE_BASE64 != ''
+        if: ${{ secrets.SIGNING_KEY_STORE_BASE64 != '' }}
         uses: timheuer/base64-to-file@v1.2
         with:
           fileName: 'keystore.jks'


### PR DESCRIPTION
Update the release workflow to use the GitHub Actions expression syntax
for the decode_keystore step condition. Replace the plain string check
if: secrets.SIGNING_KEY_STORE_BASE64 != '' with the proper expression
wrapped in ${{ ... }} so the runner evaluates the secret presence
correctly.

This ensures the decode_keystore step is conditionally executed only
when the SIGNING_KEY_STORE_BASE64 secret is set, preventing false
positives and errors during CI releases.