### PR TITLE
✨ feat(re): revamp GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,65 +1,75 @@
-name: Build and Release APK
+
+name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*'
 
 jobs:
   release:
-    name: Build and Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # To create releases and tags
-      pull-requests: read # To read commit messages
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required for analyzing commit history
+          fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Install JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+          java-version: '17'
 
-      - name: Generate Version Number
-        id: versioning
+      - name: Setup Semantic Version
+        id: version
         uses: paulhatch/semantic-version@v5.4.0
         with:
-          # Uses conventional commits (e.g., feat:, fix:, BREAKING CHANGE:)
-          # The new version is available in outputs.version
-          # This requires a GITHUB_TOKEN with write access to create tags
+          format: '{{major}}.{{minor}}.{{patch}}'
+          tag_prefix: 'v'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Update Gradle properties
+
+      - name: Update version in build.gradle
         run: |
-          echo "Setting version name to ${{ steps.versioning.outputs.version }}"
-          sed -i "s/versionName = \".*\"/versionName = \"${{ steps.versioning.outputs.version }}\"/" app/build.gradle.kts
+          sed -i "s/versionName \"1.0\"/versionName \"${{ steps.version.outputs.version }}\"/g" app/build.gradle.kts
 
-      - name: Decode Keystore
-        id: decode_keystore
-        if: ${{ secrets.SIGNING_KEY_STORE_BASE64 != '' }}
-        uses: timheuer/base64-to-file@v1.2
-        with:
-          fileName: 'keystore.jks'
-          encodedString: ${{ secrets.SIGNING_KEY_STORE_BASE64 }}
+      - name: Check for signing keystore secret
+        id: check_keystore_secret
+        run: |
+          if [ -n "${{ secrets.SIGNING_KEY_STORE_BASE64 }}" ]; then
+            echo "DECODE_KEYSTORE_ENABLED=true" >> $GITHUB_ENV
+          else
+            echo "DECODE_KEYSTORE_ENABLED=false" >> $GITHUB_ENV
+          fi
 
-      - name: Build Release APK
+      - name: Decode the keystore
+        if: ${{ env.DECODE_KEYSTORE_ENABLED == 'true' }}
+        run: |
+          echo "${{ secrets.SIGNING_KEY_STORE_BASE64 }}" | base64 --decode > app/keystore.jks
+          echo "STORE_PASSWORD=${{ secrets.SIGNING_STORE_PASSWORD }}" >> gradle.properties
+          echo "KEY_PASSWORD=${{ secrets.SIGNING_KEY_PASSWORD }}" >> gradle.properties
+          echo "KEY_ALIAS=${{ secrets.SIGNING_KEY_ALIAS }}" >> gradle.properties
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build release APK
         run: ./gradlew assembleRelease
-        env:
-          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
-          SIGNING_KEY_STORE_PATH: ${{ steps.decode_keystore.outputs.filePath }}
 
-      - name: Create GitHub Release
+      - name: Sign the APK
+        if: ${{ env.DECODE_KEYSTORE_ENABLED == 'true' }}
+        run: |
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore app/keystore.jks -storepass ${{ secrets.SIGNING_STORE_PASSWORD }} -keypass ${{ secrets.SIGNING_KEY_PASSWORD }} app/build/outputs/apk/release/app-release-unsigned.apk ${{ secrets.SIGNING_KEY_ALIAS }}
+          zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release-signed.apk
+
+      - name: Create Release
         uses: softprops/action-gh-release@v2.0.4
         with:
-          tag_name: v${{ steps.versioning.outputs.version }}
-          name: Release v${{ steps.versioning.outputs.version }}
-          generate_release_notes: true # Auto-generates release notes from commits
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          body: ${{ steps.version.outputs.changelog }}
+          draft: false
+          prerelease: false
           files: app/build/outputs/apk/release/app-release-signed.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Rename workflow to "Release" and trigger on tag pushes (v*.*.*)
  to publish releases only for version tags instead of pushes to main.
- Replace JDK setup step name and ensure java-version/temurin ordering
  remains correct.
- Swap semantic-version action to use explicit format and tag prefix,
  expose version via steps.version.outputs.version.
- Update app/build.gradle.kts versionName using the computed semantic
  version.
- Add conditional keystore handling:
  - Detect presence of SIGNING_KEY_STORE_BASE64 and set env flag.
  - Decode base64 keystore into app/keystore.jks and write signing
    credentials into gradle.properties when present.
- Ensure gradlew is executable before building.
- Build the release APK and, if keystore exists, sign and zipalign the
  APK producing app-release-signed.apk.
- Create GitHub Release using softprops/action-gh-release with tag and
  changelog from semantic-version, attach the signed APK, and pass
  GITHUB_TOKEN via env.
- Remove old permissions block and obsolete steps; simplify checkout
  fetch-depth usage.

Reason: streamline and automate versioning, signing, and release
creation for tagged releases; make keystore handling optional and safer,
and generate release artifacts with accurate semantic versions.