### PR TITLE
✨ chore: fix semantic-version action inputs in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,8 @@ jobs:
         id: semver
         uses: paulhatch/semantic-version@v5.4.0
         with:
-          format: '{{major}}.{{minor}}.{{patch}}'
+          version_format: '{{major}}.{{minor}}.{{patch}}'
           tag_prefix: 'v'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   android-build-and-publish:
     needs: calculate-version


### PR DESCRIPTION
Update the GitHub Actions release workflow to match
semantic-version v5.40 expected input names and remove
an unnecessary token parameter.

- Replace deprecated `format` input with `version_format` so the
  action correctly computes the semantic version.
- Remove the explicit `github_token` input (the action uses the
  default token automatically), avoiding a redundant parameter.

This ensures the release workflow uses the correct inputs and
prevents failed runs due to incorrect action parameters.