### PR TITLE
✨ chore: update Gradle wrapper to 8.4 distribution

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 didistributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.ziptributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update gradle/wrapper/gradle-wrapper.properties to point the
distributionUrl to Gradle 8.4 (all) instead of the previous 8.2
binary. This ensures the project uses the newer Gradle runtime with
all components bundled, enabling access to the latest fixes and
features and improving build consistency across environments. Adjust
reduces mismatch risk between developer machines and CI that expect
the updated wrapper distribution.