### PR TITLE
✨ feat(ci): use precomputed version_code and version_name in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,17 +67,13 @@ jobs:
           java-version: '17'
 
       - name: Update version in build.gradle
-        env:
-          VERSION: ${{ needs.calculate-version.outputs.version }}
         run: |
-          # Extract major, minor, patch from version
-          IFS='.' read -r major minor patch <<< "$VERSION"
-          # Calculate version code: major * 10000 + minor * 100 + patch
-          version_code=$((major * 10000 + minor * 100 + patch))
+          VERSION_NAME="${{ needs.calculate-version.outputs.version }}"
+          VERSION_CODE="${{ needs.calculate-version.outputs.version_code }}"
           
           # Update both versionCode and versionName
-          sed -i "s/versionCode = .*/versionCode = $version_code/" app/build.gradle.kts
-          sed -i "s/versionName = .*/versionName = \"$VERSION\"/" app/build.gradle.kts
+          sed -i "s/versionCode = .*/versionCode = $VERSION_CODE/" app/build.gradle.kts
+          sed -i "s/versionName = .*/versionName = "$VERSION_NAME"/" app/build.gradle.kts
 
       - name: Check for signing keystore secret
         id: check_keystore_secret


### PR DESCRIPTION
Update release workflow to consume the calculated version outputs
instead of recomputing them in the runner. The job now reads
VERSION_NAME and VERSION_CODE from needs.calculate-version outputs
and directly substitutes them into app/build.gradle.kts. This
removes fragile shell parsing of VERSION, avoids duplicated logic,
and ensures the versionCode computation is centralized in the
calculate-version step. Also fix quoting when writing versionName.