### PR TITLE
✨ chore: pass build version props from CI to Gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,15 +66,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Update version in build.gradle
-        run: |
-          VERSION_NAME="${{ needs.calculate-version.outputs.version }}"
-          VERSION_CODE="${{ needs.calculate-version.outputs.version_code }}"
-          
-          # Update both versionCode and versionName
-          sed -i "s/versionCode = .*/versionCode = $VERSION_CODE/" app/build.gradle.kts
-          sed -i "s/versionName = .*/versionName = "$VERSION_NAME"/" app/build.gradle.kts
-
       - name: Check for signing keystore secret
         id: check_keystore_secret
         run: |
@@ -96,12 +87,12 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build release APK
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease -PVERSION_NAME=${{ needs.calculate-version.outputs.version }} -PVERSION_CODE=${{ needs.calculate-version.outputs.version_code }}
 
       - name: Sign the APK
         if: ${{ env.DECODE_KEYSTORE_ENABLED == 'true' }}
         run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore app/keystore.jks -storepass ${{ secrets.SIGNING_STORE_PASSWORD }} -keypass ${{ secrets.SIGNING_KEY_PASSWORD }} app/build[...]
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore app/keystore.jks -storepass ${{ secrets.SIGNING_STORE_PASSWORD }} -keypass ${{ secrets.SIGNING_KEY_PASSWORD }} app/build[...]\
           zipalign -v 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release-signed.apk
 
       - name: Upload APK artifact

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,15 +4,20 @@ plugins {
 }
 
 android {
-    namespace = "com.audioloop.audioloop" // Assuming this is your namespace
+    namespace = "com.audioloop.audioloop"
     compileSdk = 34
 
     defaultConfig {
         applicationId = "com.audioloop.audioloop"
         minSdk = 31
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+
+        // Read version from project properties passed by GitHub Actions
+        val versionName: String = project.findProperty("VERSION_NAME") as String? ?: "1.0"
+        val versionCode: Int = (project.findProperty("VERSION_CODE") as String?)?.toInt() ?: 1
+
+        this.versionCode = versionCode
+        this.versionName = versionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -30,28 +35,22 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_17 if you configure your project for it
-        targetCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "1.8" // Or "17"
+        jvmTarget = "1.8"
     }
     buildFeatures {
-        viewBinding = true // If you use ViewBinding
-        // compose = true // If you use Jetpack Compose
+        viewBinding = true
     }
-    // packagingOptions { // Only if you have issues with duplicate files from libraries
-    //     resources {
-    //         excludes += "/META-INF/{AL2.0,LGPL2.1}"
-    //     }
-    // }
 }
 
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4") // If you use ConstraintLayout
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Hilt for Dependency Injection
 


### PR DESCRIPTION
Update CI workflow and Gradle config to set app version via
project properties instead of editing build files during the job.

- Remove fragile sed steps in release GitHub Actions; instead forward
  VERSION_NAME and VERSION_CODE as Gradle properties when running
  assembleRelease.
- Update signing/run steps to chain commands correctly after signing.
- Read VERSION_NAME and VERSION_CODE inside app/build.gradle.kts from
  project properties with safe fallbacks (defaults 1 and "1.0") and set
  versionCode/versionName accordingly.
- Clean up minor formatting/comments in build.gradle.kts.

This makes CI more robust and avoids in-place file edits during workflow
runs, keeping versioning logic centralized in Gradle.