### PR TITLE
✨ feat(release): set initial_version to ensure base versionAdd initial_version:0.1.0' to the release workflow configuration so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           major_pattern: "BREAKING CHANGE:"
           minor_pattern: "feat:"
           search_commit_body: true
+          initial_version: '0.1.0' # Added this line to ensure a base version is always available
           
       - name: Calculate Android version code
         id: version_code


### PR DESCRIPTION
a default base version is always available during automated versioning.
This prevents failures when no prior tag exists and ensures consistent
version calculation for new releases.