### PR TITLE
✨ chore(release): ensure semver fallback and debug outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,27 @@ jobs:
           minor_pattern: "feat:"
           search_commit_body: true
           initial_version: '0.1.0' # Added this line to ensure a base version is always available
+
+      - name: Debug Semantic Version Output
+        run: |
+          echo "Semantic Version Output - Version: ${{ steps.semver.outputs.version }}"
+          echo "Semantic Version Output - Version Tag: ${{ steps.semver.outputs.version_tag }}"
           
       - name: Calculate Android version code
         id: version_code
         run: |
+          VERSION_STRING="${{ steps.semver.outputs.version }}"
+          # Fallback if semantic version action outputs a placeholder
+          if [[ "$VERSION_STRING" == *"{{major}}"* ]]; then
+            echo "Semantic version output contains placeholders. Falling back to 0.1.0."
+            VERSION_STRING="0.1.0"
+          fi
+
           # Extract major, minor, patch from version
-          IFS='.' read -r major minor patch <<< "${{ steps.semver.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$VERSION_STRING"
           # Calculate version code: major * 10000 + minor * 100 + patch
           version_code=$((major * 10000 + minor * 100 + patch))
+          echo "Calculated version code: $version_code"
           echo "code=$version_code" >> $GITHUB_OUTPUT
 
   android-build-and-publish:


### PR DESCRIPTION
Add initial_version to the semantic action, log the
semantic version tag for debugging, and make the Android
code calculation robust against placeholder outputs the semver
action.

- Set initial='0.1.0' a base version is always available.
- Echo semver outputs (version and version_tag) to aid CI troubleshooting.
- Introduce VERSION_STRING with a fallback to "0.1.0" when the semver
  output contains template placeholders like "{{major}}".
- Read major/minor/patch from VERSION_STRING and print the calculated
  version code to help verify correct computation.

These changes prevent malformed version strings from breaking the Android
version code calculation and make CI failures easier to diagnose.