### PR TITLE
✨ feat(android): programmatically accept SDK licenses in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,17 @@ jobs:
           export ANDROID_HOME=$HOME/Android/sdk
           mkdir -p $ANDROID_HOME
 
+          # Create licenses directory and accept licenses programmatically
+          mkdir -p $ANDROID_HOME/licenses
+          echo "8933cc433bd4ae4c159f2a955ff9a1672b9b118" > $ANDROID_HOME/licenses/android-sdk-license
+          echo "84831b69689e956a9eb9d532aa549d65c6b89932" > $ANDROID_HOME/licenses/android-sdk-preview-license
+          echo "50466763139cbef88ac16c738be78e03be508b54" > $ANDROID_HOME/licenses/android-googletv-license
+          echo "d56f5187479451eabf01fdc167a5defb06a443a7" > $ANDROID_HOME/licenses/android-sdk-arm-dbt-license
+          echo "33777fd66d2146f8496923f173f4eac5c9f565fd" > $ANDROID_HOME/licenses/google-gdk-license
+          # The following are often included for completeness, even if not strictly needed by sdkmanager --licenses
+          echo "84831b69689e956a9eb9d532aa549d65c6b89932" > $ANDROID_HOME/licenses/mips-android-sysimage-license
+          echo "84831b69689e956a9eb9d532aa549d65c6b89932" > $ANDROID_HOME/licenses/android-googlexr-license
+          
           # Install command-line tools for Android SDK
           wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O android-cmdline-tools.zip
           unzip -q android-cmdline-tools.zip -d "$ANDROID_HOME/cmdline-tools"
@@ -113,16 +124,19 @@ jobs:
           # Set up PATH for sdkmanager and other tools
           export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
 
-          # Accept Android SDK licenses (important!)
-          yes | sdkmanager --licenses || true # '|| true' to prevent failure if no licenses need accepting
-
-          # Install a specific version of build-tools (e.g., 34.0.0, adjust if needed) and platforms (e.g., android-34)
+          # Install a specific version of build-tools (e.g., 34.0.0) and platforms (e.g., android-34)
           sdkmanager "build-tools;34.0.0" "platforms;android-34"
-          # Add build-tools to PATH
+
+          # Add build-tools to PATH permanently for this step
           export PATH=$PATH:$ANDROID_HOME/build-tools/34.0.0
 
           # Verify zipalign is now available
+          echo "Current PATH is: $PATH"
           which zipalign
+          if [ $? -ne 0 ]; then
+            echo "Error: zipalign not found after installation and PATH setup. This is a critical error."
+            exit 1
+          fi
 
       - name: Check for signing keystore secret
         id: check_keystore_secret


### PR DESCRIPTION
Create Android SDK licenses files and ensure build-tools are installed
and available in PATH during the release workflow.

- Create $ANDROID_HOME/licenses directory and add common license hashes
  so CI doesn't hang on interactive license prompts.
- Install command-line tools and use sdkmanager to install build-tools
  34.0.0 and platforms;android-34.
- Export build-tools path into PATH for the step and verify zipalign is
  present; fail the job if zipalign is missing to surface critical
  installation errors early.
- Remove redundant automatic `yes | sdkmanager --licenses` and replace
  with non-interactive license acceptance via files for more reliable CI.

This avoids interactive license prompts, makes Android setup deterministic,
and fails fast on missing tooling.