### PR TITLE
✨ feat(ci): set Android SDK 34 and preseed licenses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,16 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          sdk-platform: '34'
+          build-tools: '34.0.0'
 
       - name: Accept Android SDK licenses
-        run: yes | sdkmanager --licenses
+        run: |
+          mkdir -p $ANDROID_HOME/licenses
+          echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license
+          echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
+          echo "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
 
       - name: Cache Gradle packages
         uses: actions/cache@v3


### PR DESCRIPTION
Set the Android SDK platform to 34 and build-tools to 34.0.0 in the
release workflow, and replace interactive sdkmanager license acceptance
with pre-seeded license files under $ANDROID_HOME/licenses.

This ensures CI does not hang waiting for interactive license prompts
and guarantees consistent Android tool versions for builds and releases.